### PR TITLE
docs: add AsAllowedCallable requirement for TYPO3 v14

### DIFF
--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -466,6 +466,44 @@ grep -rn "'type'\s*=>\s*'text'" Configuration/TCA/
 
 ## v13 → v14 Upgrade
 
+### TypoScript/TSconfig Callables Require #[AsAllowedCallable] Attribute (Critical)
+
+> **Breaking: #108054** - [Changelog](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108054-EnforceExplicitOpt-inForTypoScriptTSconfigCallables.html)
+
+TYPO3 v14 requires explicit opt-in for methods callable through TypoScript/TSconfig. Without the attribute, calls fail with `AllowedCallableException`.
+
+**Search Pattern**
+```bash
+# Find TypoScript userFunc references
+grep -rn "userFunc\|preUserFunc\|postUserFunc" Configuration/TypoScript/
+# Find PHP classes referenced in TypoScript
+grep -rn "->render\|->process" Configuration/TypoScript/ | grep -v "#"
+```
+
+**Affected**
+- `userFunc` in USER/USER_INT content objects
+- `preUserFunc`, `postUserFunc`, `preUserFuncInt`, `postUserFuncInt` in stdWrap
+- TSconfig `renderFunc` in suggest wizard
+
+**Fix**: Add `#[AsAllowedCallable]` attribute to all TypoScript-callable methods:
+
+```php
+use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
+
+class MyProcessor
+{
+    #[AsAllowedCallable]
+    public function process(?string $content, array $conf, ServerRequestInterface $request): string
+    {
+        return $content ?? '';
+    }
+}
+```
+
+**Version Compatibility**: The attribute was backported to TYPO3 13.4.21. Extensions requiring `^13.4 || ^14.0` must update minimum to `^13.4.21 || ^14.0`.
+
+**Note**: No Rector rule exists for this change. Manual review of TypoScript configurations required.
+
 ### ExtensionConfiguration::getAll() Removed (Critical)
 
 **Search Pattern**


### PR DESCRIPTION
## Summary
- Document Breaking #108054 - TypoScript/TSconfig callables require `#[AsAllowedCallable]` attribute in TYPO3 v14
- Add search patterns to find affected code
- Include migration example
- Note version compatibility (backported to 13.4.21)
- Note that no Rector rule exists

## Context
This breaking change was discovered during PR review of https://github.com/netresearch/t3x-rte_ckeditor_image/pull/518 - the existing tooling (Rector, skills) did not catch this requirement.

## References
- [Breaking: #108054](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108054-EnforceExplicitOpt-inForTypoScriptTSconfigCallables.html)
- [TYPO3 13.4.21 Release Notes](https://get.typo3.org/release-notes/13.4.21) (backport)