### PR TITLE
feat: add upgrade planner agent and assessment commands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,14 +1,21 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "2.0.2",
-  "description": "Systematic TYPO3 extension upgrades to newer LTS versions",
+  "version": "3.0.0",
+  "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "MIT",
   "author": {
     "name": "Netresearch DTT GmbH",
-    "email": "info@netresearch.de"
+    "url": "https://www.netresearch.de"
   },
   "skills": [
     "./skills/typo3-extension-upgrade"
+  ],
+  "agents": [
+    "./agents/upgrade-planner.md"
+  ],
+  "commands": [
+    "./commands/assess.md",
+    "./commands/rector.md"
   ]
 }

--- a/agents/upgrade-planner.md
+++ b/agents/upgrade-planner.md
@@ -1,0 +1,84 @@
+---
+name: "upgrade-planner"
+description: "Plan TYPO3 extension upgrades with breaking change analysis"
+model: "sonnet"
+---
+
+# TYPO3 Extension Upgrade Planner
+
+You are a specialized agent for planning TYPO3 extension upgrades. You analyze extensions and create comprehensive upgrade plans.
+
+## Your Capabilities
+
+1. **Version Analysis**
+   - Detect current TYPO3 version constraints
+   - Identify PHP version requirements
+   - Map deprecations to breaking changes
+
+2. **Breaking Change Detection**
+   - Scan for deprecated API usage
+   - Identify removed classes/methods
+   - Check FlexForm structure changes
+   - Analyze TypoScript migrations needed
+
+3. **Migration Planning**
+   - Rector rule recommendations
+   - Fractor migration rules
+   - Manual changes required
+   - Testing strategy
+
+## Workflow
+
+When asked to plan an upgrade:
+
+1. **Analyze current state**
+   - Read ext_emconf.php and composer.json
+   - Identify current TYPO3 version
+   - List all dependencies
+
+2. **Scan for issues**
+   - Search for deprecated APIs
+   - Check for removed features
+   - Identify configuration changes
+
+3. **Generate upgrade plan**
+
+```markdown
+## TYPO3 Extension Upgrade Plan
+
+**Extension:** {ext_key}
+**Current:** TYPO3 {from_version}
+**Target:** TYPO3 {to_version}
+
+### Phase 1: Preparation
+- [ ] Update composer.json version constraints
+- [ ] Run Extension Scanner
+- [ ] Review deprecation log
+
+### Phase 2: Automated Migrations
+- [ ] Run Rector with TYPO3 rules
+- [ ] Run Fractor for non-PHP files
+- [ ] Verify automated changes
+
+### Phase 3: Manual Changes
+| File | Change Required | Effort |
+|------|-----------------|--------|
+| {file} | {description} | {hours}h |
+
+### Phase 4: Testing
+- [ ] Unit tests pass
+- [ ] Functional tests pass
+- [ ] Manual QA
+
+### Risk Assessment
+- High risk areas: {list}
+- Estimated effort: {hours} hours
+```
+
+## Output
+
+Provide actionable, step-by-step plans with:
+- Specific file changes needed
+- Rector/Fractor rules to apply
+- Manual migration code examples
+- Testing checklist

--- a/commands/assess.md
+++ b/commands/assess.md
@@ -1,0 +1,67 @@
+---
+description: "Assess extension upgrade complexity and effort"
+---
+
+# Upgrade Assessment
+
+Quickly assess the upgrade complexity for a TYPO3 extension.
+
+## Steps
+
+1. **Detect versions**
+   ```bash
+   # Read current constraints
+   cat composer.json | grep -A5 "typo3/cms"
+   cat ext_emconf.php | grep -A5 "constraints"
+   ```
+
+2. **Run Extension Scanner**
+   ```bash
+   # If DDEV available
+   ddev exec vendor/bin/typo3 extensionscanner:scan --extension-key=myext
+   ```
+
+3. **Count deprecated usages**
+   ```bash
+   # Search for common deprecations
+   grep -r "GeneralUtility::makeInstance" Classes/ | wc -l
+   grep -r "\$GLOBALS\['TYPO3_DB'\]" Classes/ | wc -l
+   grep -r "extbase" Configuration/TCA/ | wc -l
+   ```
+
+4. **Check for Rector support**
+   ```bash
+   # Verify rector is available
+   composer show ssch/typo3-rector 2>/dev/null || echo "Rector not installed"
+   ```
+
+5. **Generate assessment**
+
+   ```
+   ## Upgrade Assessment: {extension}
+
+   ### Version Jump
+   From: TYPO3 {from} / PHP {php_from}
+   To: TYPO3 {to} / PHP {php_to}
+
+   ### Complexity: {Low|Medium|High|Very High}
+
+   ### Issues Found
+   - Deprecated APIs: X occurrences
+   - Removed features: Y usages
+   - Configuration changes: Z files
+
+   ### Recommended Approach
+   1. {approach}
+
+   ### Estimated Effort
+   - Automated: X hours
+   - Manual: Y hours
+   - Testing: Z hours
+   - **Total: N hours**
+   ```
+
+6. **Recommend next steps**
+   - Suggest starting with Rector
+   - Identify manual-only changes
+   - Propose testing strategy

--- a/commands/rector.md
+++ b/commands/rector.md
@@ -1,0 +1,63 @@
+---
+description: "Run Rector migrations for TYPO3 upgrade"
+---
+
+# Run Rector Migrations
+
+Execute Rector with TYPO3-specific rules for automated code migration.
+
+## Steps
+
+1. **Verify Rector installation**
+   ```bash
+   composer show ssch/typo3-rector || composer require --dev ssch/typo3-rector
+   ```
+
+2. **Create/update rector.php config**
+
+   ```php
+   <?php
+   use Rector\Config\RectorConfig;
+   use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
+
+   return static function (RectorConfig $rectorConfig): void {
+       $rectorConfig->paths([
+           __DIR__ . '/Classes',
+           __DIR__ . '/Configuration',
+       ]);
+
+       // Choose target version
+       $rectorConfig->sets([
+           Typo3LevelSetList::UP_TO_TYPO3_12,
+           // or Typo3LevelSetList::UP_TO_TYPO3_13,
+       ]);
+   };
+   ```
+
+3. **Run in dry-run mode first**
+   ```bash
+   vendor/bin/rector process --dry-run
+   ```
+
+4. **Review proposed changes**
+   - Check each file modification
+   - Verify no unwanted changes
+   - Note any manual follow-ups needed
+
+5. **Apply changes**
+   ```bash
+   vendor/bin/rector process
+   ```
+
+6. **Run tests after Rector**
+   ```bash
+   composer test
+   # or
+   vendor/bin/phpunit
+   ```
+
+7. **Commit Rector changes**
+   ```bash
+   git add -A
+   git commit -m "refactor: apply Rector TYPO3 {version} migrations"
+   ```


### PR DESCRIPTION
## Summary

- Adds `upgrade-planner` agent for comprehensive upgrade planning
- Adds `/assess` command for quick complexity assessment  
- Adds `/rector` command for running Rector migrations

## Changes

- `agents/upgrade-planner.md`: Full upgrade planning workflow
- `commands/assess.md`: Quick assessment workflow
- `commands/rector.md`: Rector execution guide
- `.claude-plugin/plugin.json`: Added agents/commands, bumped to v3.0.0

## Test Plan

- [ ] Run /assess on a TYPO3 extension
- [ ] Verify upgrade-planner generates comprehensive plans
- [ ] Test /rector workflow