### PR TITLE
chore: replace generic emails with GitHub references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
   "authors": [
     {
       "name": "Netresearch DTT GmbH",
-      "email": "info@netresearch.de",
       "homepage": "https://www.netresearch.de/",
       "role": "Manufacturer"
     }
@@ -16,5 +15,9 @@
   },
   "extra": {
     "ai-agent-skill": "SKILL.md"
+  },
+  "support": {
+    "issues": "https://github.com/netresearch/typo3-extension-upgrade-skill/issues",
+    "source": "https://github.com/netresearch/typo3-extension-upgrade-skill"
   }
 }


### PR DESCRIPTION
## Summary

- Replace generic `@netresearch.de` email addresses with GitHub-native references
- Add `support` section to package metadata with Issues/Source URLs
- Use GitHub Security Advisories for vulnerability reporting
- Use GitHub Issues for general support/contact

## Motivation

Generic email addresses in public repositories attract spam and create maintenance overhead. GitHub provides better mechanisms for each use case:
- **Security**: Private vulnerability reporting via Security Advisories
- **Support**: Issue tracker with templates and labels
- **Contact**: Discussions for general questions

## Test plan

- [ ] Verify package metadata is valid (composer validate)
- [ ] Verify links in documentation point to correct URLs
- [ ] Verify no functional email addresses were removed (only metadata/docs)
