### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+.vscode/
+*.swp
+.DS_Store
+vendor/
+composer.lock


### PR DESCRIPTION
Add standard .gitignore for skill repos (IDE files, vendor, composer.lock).