### PR TITLE
feat: add skill validation CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
+
+  validate:
+    name: Skill Validation
+    uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main


### PR DESCRIPTION
## Summary
- Add skill validation job calling reusable workflow from skill-repo-skill
- Checks SKILL.md frontmatter, word count, composer.json, plugin.json, file presence

## Test plan
- [ ] CI passes with new validation job