### PR TITLE
docs: add cross-version Fluid and PHP patterns (v12/v13/v14)

### DIFF
--- a/skills/typo3-extension-upgrade/references/dual-compatibility.md
+++ b/skills/typo3-extension-upgrade/references/dual-compatibility.md
@@ -1,6 +1,6 @@
-# TYPO3 v12 + v13 Dual Compatibility
+# TYPO3 Multi-Version Compatibility (v12 + v13 + v14)
 
-When extension must support BOTH `^12.4 || ^13.4`.
+When extension must support `^12.4 || ^13.4 || ^14.1`.
 
 ## Version Constraints
 
@@ -8,7 +8,7 @@ When extension must support BOTH `^12.4 || ^13.4`.
 {
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "^12.4 || ^13.4"
+        "typo3/cms-core": "^12.4 || ^13.4 || ^14.1"
     }
 }
 ```
@@ -17,8 +17,8 @@ When extension must support BOTH `^12.4 || ^13.4`.
 // ext_emconf.php
 'constraints' => [
     'depends' => [
-        'typo3' => '12.4.0-13.4.99',
-        'php' => '8.2.0-8.4.99',
+        'typo3' => '12.4.0-14.99.99',
+        'php' => '8.2.0-8.99.99',
     ],
 ],
 ```
@@ -45,6 +45,85 @@ $rectorConfig->sets([
 | Page info | `$data['pObj']->rootLine` | `$request->getAttribute('frontend.page.information')` |
 
 **Rule**: Always use v12-compatible APIs when supporting both versions.
+
+## Fluid Template Cross-Version Patterns
+
+### f:be.infobox state parameter
+
+The `state` argument type differs across versions:
+
+| Version | `state` type | Accepts |
+|---------|-------------|---------|
+| v12 | `int` | `InfoboxViewHelper::STATE_*` integer constants |
+| v13 | `int` | `InfoboxViewHelper::STATE_*` integer constants |
+| v14 | `mixed` | `ContextualFeedbackSeverity` enum OR integer |
+
+**Rule**: Always use `InfoboxViewHelper::STATE_*` constants. Never use
+`ContextualFeedbackSeverity` enum for `f:be.infobox` state — it breaks v12/v13.
+
+Verified: `STATE_*` constants exist in v12.4, v13.4, and v14.2.
+
+```html
+<!-- CORRECT: works on v12/v13/v14 -->
+<f:be.infobox title="Note" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}">
+
+<!-- WRONG: breaks v12/v13 (state expects int, gets enum object) -->
+<f:be.infobox title="Note" state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}">
+```
+
+Constants: `STATE_NOTICE` (-2), `STATE_INFO` (-1), `STATE_OK` (0),
+`STATE_WARNING` (1), `STATE_ERROR` (2).
+
+### Badge CSS classes
+
+Use `badge-*` classes. TYPO3 core uses `badge badge-success` etc. in its
+own backend templates (e.g., MFA overview) across all versions:
+
+```html
+<span class="badge badge-success">Active</span>
+```
+
+## PHP Cross-Version Patterns
+
+### IconSize enum (v13+)
+
+| Version | `IconFactory::getIcon()` $size | Available |
+|---------|-------------------------------|-----------|
+| v12 | `string` (untyped) | `Icon::SIZE_SMALL` etc. |
+| v13 | `IconSize` enum | Both enum and deprecated constants |
+| v14 | `IconSize` enum (strict) | `IconSize::SMALL` only |
+
+**Pattern**: Use `enum_exists()` with argument unpacking for cross-version compat:
+
+```php
+use TYPO3\CMS\Core\Imaging\IconSize;
+
+$icon = $this->iconFactory->getIcon(
+    'actions-question-circle',
+    ...(\enum_exists(IconSize::class) ? [IconSize::SMALL] : ['small']),
+);
+```
+
+Add PHPStan ignoreErrors for the mixed-type warning:
+
+```neon
+# phpstan.neon
+parameters:
+    ignoreErrors:
+        -
+            message: '#IconSize#'
+            path: %currentWorkingDirectory%/Classes/Controller/MyController.php
+            reportUnmatched: false
+        -
+            message: '#expects string, mixed given#'
+            path: %currentWorkingDirectory%/Classes/Controller/MyController.php
+            reportUnmatched: false
+```
+
+### PHPStan inline ignores
+
+**Never use `@phpstan-ignore` in code** — CI configs may reject inline ignores.
+Always use `phpstan.neon` `ignoreErrors` with `reportUnmatched: false`.
 
 ## Third-Party Dependency Dual Compatibility
 


### PR DESCRIPTION
## Summary

Adds documented cross-version compatibility patterns from real-world experience building a TYPO3 extension supporting v12+v13+v14 simultaneously.

### Patterns added

- **`f:be.infobox` state**: Use `InfoboxViewHelper::STATE_*` integer constants, never `ContextualFeedbackSeverity` enum (breaks v12/v13 where state is typed as `int`)
- **Badge CSS classes**: Use `badge-*` (TYPO3 convention), not Bootstrap 5 `text-bg-*`
- **`IconSize` enum**: `enum_exists()` + argument unpacking for v12 compat where `IconSize` doesn't exist
- **PHPStan**: Use `phpstan.neon` `ignoreErrors`, never inline `@phpstan-ignore` (CI may reject)

### Context

These patterns were discovered while adding dashboard UX features to `netresearch/nr-passkeys-be` that needed to work across all three TYPO3 LTS versions. Each pattern caused CI failures on at least one version before the correct cross-version approach was found.