### PR TITLE
fix(checkpoints): accept Build/ subdir layouts for rector/fractor

### DIFF
--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -6,35 +6,37 @@ skill_id: typo3-extension-upgrade
 
 mechanical:
   # === RECTOR CONFIGURATION ===
+  # Accept both root and Build/ subdirectory layouts (common in extensions that
+  # keep testing/CI tooling under Build/). Build/rector/rector.php is the
+  # Netresearch default when using a split Build/ structure.
   - id: TU-01
     type: file_exists
-    target: rector.php
+    target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
     severity: warning
-    desc: "rector.php should exist for automated code migration"
+    desc: "rector.php should exist for automated code migration (root or Build/ subdir)"
 
   - id: TU-02
     type: command
-    pattern: "grep -l 'Typo3LevelSetList' rector.php Build/rector.php 2>/dev/null | head -1"
+    pattern: "grep -l 'Typo3LevelSetList' rector.php Build/rector.php Build/rector/rector.php 2>/dev/null | head -1"
     severity: warning
     desc: "Rector config should use TYPO3 level sets for version upgrades"
 
   - id: TU-03
     type: command
-    pattern: "grep -l 'RectorConfig' rector.php Build/rector.php 2>/dev/null | head -1"
+    pattern: "grep -l 'RectorConfig' rector.php Build/rector.php Build/rector/rector.php 2>/dev/null | head -1"
     severity: warning
     desc: "Rector config should use modern RectorConfig format"
 
   # === FRACTOR CONFIGURATION (TypoScript/Fluid) ===
   - id: TU-04
     type: file_exists
-    target: fractor.php
+    target: "{fractor.php,Build/fractor.php,Build/fractor/fractor.php}"
     severity: info
-    desc: "fractor.php should exist for TypoScript/Fluid migration"
+    desc: "fractor.php should exist for TypoScript/Fluid migration (root or Build/ subdir)"
 
   - id: TU-05
-    type: contains
-    target: fractor.php
-    pattern: "Typo3LevelSetList"
+    type: command
+    pattern: "grep -l 'Typo3LevelSetList' fractor.php Build/fractor.php Build/fractor/fractor.php 2>/dev/null | head -1"
     severity: info
     desc: "Fractor config should use TYPO3 level sets"
 

--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -9,6 +9,12 @@ mechanical:
   # Accept both root and Build/ subdirectory layouts (common in extensions that
   # keep testing/CI tooling under Build/). Build/rector/rector.php is the
   # Netresearch default when using a split Build/ structure.
+  #
+  # All checks here use `command` checkpoints that loop over candidate paths
+  # and only `grep` files that actually exist — `grep -l a b c` exits with
+  # status 2 when any listed file is missing, which would otherwise mask real
+  # matches in other candidates. The runner's brace-expansion in `file_exists`
+  # is used for TU-01/TU-04 since those are pure existence checks.
   - id: TU-01
     type: file_exists
     target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
@@ -17,13 +23,13 @@ mechanical:
 
   - id: TU-02
     type: command
-    pattern: "grep -l 'Typo3LevelSetList' rector.php Build/rector.php Build/rector/rector.php 2>/dev/null | head -1"
+    pattern: 'for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0; done; exit 1'
     severity: warning
     desc: "Rector config should use TYPO3 level sets for version upgrades"
 
   - id: TU-03
     type: command
-    pattern: "grep -l 'RectorConfig' rector.php Build/rector.php Build/rector/rector.php 2>/dev/null | head -1"
+    pattern: 'for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && grep -q "RectorConfig" "$f" && exit 0; done; exit 1'
     severity: warning
     desc: "Rector config should use modern RectorConfig format"
 
@@ -36,7 +42,7 @@ mechanical:
 
   - id: TU-05
     type: command
-    pattern: "grep -l 'Typo3LevelSetList' fractor.php Build/fractor.php Build/fractor/fractor.php 2>/dev/null | head -1"
+    pattern: 'for f in fractor.php Build/fractor.php Build/fractor/fractor.php; do [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0; done; exit 1'
     severity: info
     desc: "Fractor config should use TYPO3 level sets"
 


### PR DESCRIPTION
## Summary

Many Netresearch extensions keep testing/CI tooling under a \`Build/\` subdirectory — rector config lives at \`Build/rector/rector.php\`, fractor at \`Build/fractor/fractor.php\`. The previous checkpoints only looked at repo root and reported warnings/info on every project using the split layout.

## Change

TU-01 and TU-04 now accept three common locations via brace expansion:

- \`rector.php\` (monolithic root)
- \`Build/rector.php\` (Build/ flat)
- \`Build/rector/rector.php\` (Build/ subdir — Netresearch default)

Same for fractor. Also extended the \`grep -l\` fallback in TU-02/TU-03/TU-05 to look in the Build/<tool>/ subdir. TU-05 changed from \`contains\` to \`command\` so it can scan multiple candidate files.

## Verification

Against netresearch/t3x-nr-llm (Build/ subdir layout):

| Checkpoint | Before | After |
|---|---|---|
| TU-01 rector.php exists | warning — not found | pass — \`Build/rector/rector.php\` |
| TU-02 TYPO3 level sets | warning — command failed | pass |
| TU-03 RectorConfig format | warning — command failed | pass |
| TU-04 fractor.php exists | info — not found | pass — \`Build/fractor/fractor.php\` |
| TU-05 fractor level sets | info — target not found | pass |

## Test plan

- [ ] CI green
- [x] Manual: all five pass against t3x-nr-llm