### PR TITLE
feat(typo3-extension-upgrade): document getIndpEnv() v14.3 deprecation + NormalizedParams migration

### DIFF
--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -731,7 +731,7 @@ $icon = $iconFactory->getIcon('actions-edit', 'small');
 
 > **Deprecated: v14.3, scheduled for removal in v15.0**
 > **Source**: `typo3/cms-core` v14.3.0 vendor source, `Classes/Utility/GeneralUtility.php` (the `@deprecated` tag is on the method itself).
-> **Verify locally**: `grep -n "@deprecated" vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php | grep -i getIndpEnv -A0 -B0` (then read 5 lines of context).
+> **Verify locally**: `grep -n -B5 "function getIndpEnv(" vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php` -- shows the docblock with `@deprecated since TYPO3 v14.3, will be removed in TYPO3 v15.0` directly above the method signature (line ~2142 in v14.3.0).
 
 `GeneralUtility::getIndpEnv($name)` is deprecated since **TYPO3 v14.3** and scheduled for removal in **v15.0**. Replacement is `NormalizedParams` from the PSR-7 request.
 

--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -727,6 +727,84 @@ if (class_exists(IconSize::class)) {
 $icon = $iconFactory->getIcon('actions-edit', 'small');
 ```
 
+### GeneralUtility::getIndpEnv() Deprecated -- Use NormalizedParams (v14.3)
+
+> **Deprecated: v14.3, scheduled for removal in v15.0**
+> **Source**: `typo3/cms-core` v14.3.0 vendor source, `Classes/Utility/GeneralUtility.php` (the `@deprecated` tag is on the method itself).
+> **Verify locally**: `grep -n "@deprecated" vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php | grep -i getIndpEnv -A0 -B0` (then read 5 lines of context).
+
+`GeneralUtility::getIndpEnv($name)` is deprecated since **TYPO3 v14.3** and scheduled for removal in **v15.0**. Replacement is `NormalizedParams` from the PSR-7 request.
+
+> ⚠️ Don't trust AI assistants on this deprecation timing. Gemini Code Assist has been observed claiming `getIndpEnv()` was deprecated in v13.0 / removed in v14.0, and that `NormalizedParams::createFromServerParams()` was removed in v14.0 in favour of a (non-existent) `NormalizedParamsFactory` class. All three claims are wrong -- verified false against `typo3/cms-core` v14.3.0 vendor source. Always verify deprecation timing by reading the `@deprecated` annotation in `vendor/typo3/cms-core/`.
+
+**Search Pattern**
+```bash
+grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/
+```
+
+**Method mapping** (`getIndpEnv($name)` → `NormalizedParams` method)
+
+| `getIndpEnv()` argument | `NormalizedParams` method |
+|---|---|
+| `'REMOTE_ADDR'` | `getRemoteAddress()` |
+| `'HTTP_HOST'` | `getHttpHost()` |
+| `'TYPO3_SSL'` | `isHttps()` |
+| `'HTTP_REFERER'` | `getHttpReferer()` |
+| `'REQUEST_URI'` | `getRequestUri()` |
+| `'SCRIPT_NAME'` | `getScriptName()` |
+| `'TYPO3_REQUEST_HOST'` | `getRequestHost()` |
+| `'TYPO3_REQUEST_URL'` | `getRequestUrl()` |
+| `'TYPO3_SITE_URL'` | `getSiteUrl()` |
+| `'TYPO3_SITE_PATH'` | `getSitePath()` |
+
+**Replace -- in controllers/middleware (request injected)**
+```php
+// ❌ Before
+$ip = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+
+// ✅ After (PSR-7 request available)
+$ip = $request->getAttribute('normalizedParams')?->getRemoteAddress() ?? '';
+```
+
+**Replace -- in services/auth services (no request injected)**
+
+For services where `ServerRequestInterface` cannot be injected (e.g. `AbstractAuthenticationService` subclasses, CLI commands), fall back through `$GLOBALS['TYPO3_REQUEST']` and finally re-create `NormalizedParams` from `$_SERVER`:
+
+```php
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+
+private function getRemoteAddress(): string
+{
+    // 1. Prefer PSR-7 request (set in middleware-driven flows)
+    $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+    if ($request instanceof ServerRequestInterface) {
+        $params = $request->getAttribute('normalizedParams');
+        if ($params instanceof NormalizedParams) {
+            return $params->getRemoteAddress();
+        }
+    }
+
+    // 2. CLI / test fallback -- createFromServerParams() exists and is callable
+    //    in v14.3 (verified at NormalizedParams.php:306, marked only @internal,
+    //    NOT @deprecated).
+    $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+    $sysConf = is_array($confVars) && isset($confVars['SYS']) && is_array($confVars['SYS'])
+        ? $confVars['SYS']
+        : [];
+
+    return NormalizedParams::createFromServerParams($_SERVER, $sysConf)->getRemoteAddress();
+}
+```
+
+**Dual-version compatibility (v12.4 + v13.4 + v14.3)**
+
+The migration is safe across the entire supported range with **no compatibility shims**: `NormalizedParams` has been part of TYPO3 since v9.4, and `normalizedParams` has been a request attribute since v10. Just migrate to `NormalizedParams` in one step -- it works on v12.4 / v13.4 / v14.3 unchanged, and silences the v14.3 deprecation.
+
+**Reference migration**: [netresearch/t3x-nr-passkeys-be commit b2cfd8e](https://github.com/netresearch/t3x-nr-passkeys-be/commit/b2cfd8e) (v14.3 upgrade [#57](https://github.com/netresearch/t3x-nr-passkeys-be/pull/57)).
+
+**No Rector rule yet** (as of v14.3 / typo3-rector 3.x). Manual `grep` + replace required.
+
 ### Additional v14 Changes
 
 Monitor [Changelog-14](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-14.html) for additional breaking changes.
@@ -735,6 +813,9 @@ Monitor [Changelog-14](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Change
 - `ExtensionConfiguration::getAll()` - use `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']`
 - `Type::getName()` in Doctrine DBAL - use `instanceof` checks
 - `Icon::SIZE_*` constants - use `IconSize` enum
+
+**Known Deprecations (v14.3, removal in v15.0)**
+- `GeneralUtility::getIndpEnv()` - use `NormalizedParams` from PSR-7 request
 
 ---
 
@@ -917,6 +998,8 @@ When supporting multiple versions (e.g., `^12.4 || ^13.4`):
 | `$_GET['param'] ?? null` | ✅ | ✅ | ✅ | ✅ |
 | `$TSFE->fe_user` | ✅ | ✅ | ⚠️ | ❌ |
 | `$request->getAttribute('frontend.user')` | ❌ | ❌ | ✅ | ✅ |
+| `GeneralUtility::getIndpEnv()` | ✅ | ✅ | ✅ | ⚠️ (v14.3) |
+| `$request->getAttribute('normalizedParams')` | ✅ | ✅ | ✅ | ✅ |
 | Signal/Slot | ⚠️ | ❌ | ❌ | ❌ |
 | PSR-14 Events | ✅ | ✅ | ✅ | ✅ |
 
@@ -946,6 +1029,9 @@ grep -rn "PDO::PARAM_\|GeneralUtility::_GET\|itemFormElID" Classes/
 
 # v12→v13: TSFE direct access
 grep -rn "\$TSFE->fe_user\|\$TSFE->page\|\$TSFE->rootLine" Classes/
+
+# v13→v14.3: getIndpEnv() deprecation (use NormalizedParams)
+grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/
 
 # PHP 8.4: Implicit nullable parameters
 grep -rn '\$[a-zA-Z_]* = null)' Classes/ | grep -v '?'

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -124,6 +124,18 @@ All 98 breakers landed in v14.0. **If your extension compiles against v14.0, it'
 | Frontend HTTP compression removed | #107943 | check TypoScript `config.compressionLevel` | Delegate to web server (nginx/Apache) |
 | Extbase `ActionController->view` typed | #105377 | — | Type-check any custom controller overrides |
 
+### v14.x deprecations (still callable, removed in v15.0)
+
+These are **not** v14.0 breakers — code keeps working — but you should migrate to silence deprecation notices and prepare for v15.
+
+| Change | Forge / Source | Search | Fix |
+|---|---|---|---|
+| `GeneralUtility::getIndpEnv()` deprecated (v14.3) | `cms-core` v14.3 — `Classes/Utility/GeneralUtility.php` `@deprecated` annotation | `grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/` | `$request->getAttribute('normalizedParams')->getRemoteAddress()` etc. — see `api-changes.md` |
+
+> ⚠️ **AI-assistant warning**: Don't trust Gemini Code Assist on `getIndpEnv()` deprecation timing. It has hallucinated v13.0 deprecation / v14.0 removal, and falsely claimed `NormalizedParams::createFromServerParams()` was removed in v14.0 in favour of a non-existent `NormalizedParamsFactory`. All three claims are wrong — verified false against `typo3/cms-core` v14.3.0 vendor source. Always grep the `@deprecated` annotation in `vendor/typo3/cms-core/` to confirm.
+
+The migration is safe across **v12.4 + v13.4 + v14.3** without compatibility shims — `NormalizedParams` is in core since v9.4, `normalizedParams` request attribute since v10. Reference migration: [netresearch/t3x-nr-passkeys-be commit b2cfd8e](https://github.com/netresearch/t3x-nr-passkeys-be/commit/b2cfd8e) (v14.3 upgrade [PR #57](https://github.com/netresearch/t3x-nr-passkeys-be/pull/57)).
+
 ### FAL / File handling
 
 | Change | Forge | Fix |


### PR DESCRIPTION
## Summary

Captures one lesson from the [TYPO3 v14.3 upgrade in `netresearch/t3x-nr-passkeys-be`](https://github.com/netresearch/t3x-nr-passkeys-be/pull/57): `GeneralUtility::getIndpEnv()` was deprecated in **v14.3** (not v13.0, not v14.0 — those are AI hallucinations) and is scheduled for removal in **v15.0**. Replacement is `NormalizedParams` from the PSR-7 request, callable across v12.4 / v13.4 / v14.3 with **no compatibility shims**.

### Changes

- **`references/api-changes.md`** — new `### GeneralUtility::getIndpEnv() Deprecated -- Use NormalizedParams (v14.3)` subsection under `## v13 → v14 Upgrade` with:
  - Primary-source citation (`@deprecated` annotation in `typo3/cms-core` v14.3.0 vendor source)
  - Method mapping table (`REMOTE_ADDR` → `getRemoteAddress()`, `HTTP_HOST` → `getHttpHost()`, etc.)
  - Two migration patterns: controller (`$request->getAttribute('normalizedParams')`) and service/auth-service (`$GLOBALS['TYPO3_REQUEST']` chain → `NormalizedParams::createFromServerParams($_SERVER, $sysConf)` CLI/test fallback)
  - AI-assistant warning section calling out specific Gemini Code Assist hallucinations
  - Dual-version compatibility note (works on v12.4 / v13.4 / v14.3 unchanged — `NormalizedParams` is in core since v9.4, `normalizedParams` request attribute since v10)
  - Reference migration link: [`netresearch/t3x-nr-passkeys-be@b2cfd8e`](https://github.com/netresearch/t3x-nr-passkeys-be/commit/b2cfd8e)
  - Adds rows to the dual-version compatibility matrix and the quick-search commands at the bottom of the file.
- **`references/upgrade-v13-to-v14.md`** — new `### v14.x deprecations (still callable, removed in v15.0)` mini-section with the deprecation row, an AI-assistant warning, and a pointer to `api-changes.md`. Inserted after the `Critical (most-hit)` v14.0 breakers and before `### FAL / File handling`. Categorically distinct from the v14.0-only breaking-changes table.

### Why this matters

Gemini Code Assist has been observed claiming during PR review that `getIndpEnv()` was deprecated in v13.0 and removed in v14.0, and that `NormalizedParams::createFromServerParams()` was removed in favour of a (non-existent) `NormalizedParamsFactory` class. **All three claims are wrong** — verified false against `typo3/cms-core` v14.3.0 vendor source:
- `Classes/Utility/GeneralUtility.php:2142` — `@deprecated since TYPO3 v14.3, will be removed in TYPO3 v15.0`
- `Classes/Http/NormalizedParams.php:306` — `createFromServerParams()` exists, marked only `@internal`, no `@deprecated`
- No `NormalizedParamsFactory` class exists anywhere in v14.3 core

This PR documents the correct timing and migration so the next maintainer running an upgrade has primary-source-cited guidance instead of AI hallucinations.

## Test plan

- [x] `bash scripts/verify-harness.sh` -- Level 2 PARTIAL, 0 errors, 1 unrelated warning
- [x] Commit is GPG-signed (`info@sebastianmendel.de` ED25519) and DCO `Signed-off-by` matches `git config user.email`
- [x] Conventional commit prefix (`feat(typo3-extension-upgrade):`)
- [x] No AI attribution in commit/PR body
- [x] All cross-references between the two files resolve
- [x] Verified `getIndpEnv\|NormalizedParams\|normalizedParams` was not previously documented anywhere in `skills/`