### PR TITLE
feat(typo3-extension-upgrade): document v12/v13/v14 compat gotchas

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -59,6 +59,7 @@ Config templates in `assets/`: `rector.php`, `fractor.php`, `phpstan.neon`, `php
 |-----------|-------------|
 | `references/pre-upgrade.md` | Starting an upgrade: planning checklist, version audit, risk assessment |
 | `references/api-changes.md` | Checking deprecated/removed APIs by TYPO3 version |
+| `references/api-traps.md` | Cross-version footguns: silent TCA restrictions, boot-order rules, DI bypass, path-doubling |
 | `references/upgrade-v11-to-v12.md` | Upgrading from TYPO3 v11 to v12 |
 | `references/upgrade-v12-to-v13.md` | Upgrading from TYPO3 v12 to v13 |
 | `references/upgrade-v13-to-v14.md` | Upgrading from TYPO3 v13 to v14 |

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -59,7 +59,7 @@ Config templates in `assets/`: `rector.php`, `fractor.php`, `phpstan.neon`, `php
 |-----------|-------------|
 | `references/pre-upgrade.md` | Starting an upgrade: planning checklist, version audit, risk assessment |
 | `references/api-changes.md` | Checking deprecated/removed APIs by TYPO3 version |
-| `references/api-traps.md` | Cross-version footguns: silent TCA restrictions, boot-order rules, DI bypass, path-doubling |
+| `references/api-traps.md` | Cross-version footguns: TCA restrictions, boot order, DI bypass |
 | `references/upgrade-v11-to-v12.md` | Upgrading from TYPO3 v11 to v12 |
 | `references/upgrade-v12-to-v13.md` | Upgrading from TYPO3 v12 to v13 |
 | `references/upgrade-v13-to-v14.md` | Upgrading from TYPO3 v13 to v14 |

--- a/skills/typo3-extension-upgrade/references/api-traps.md
+++ b/skills/typo3-extension-upgrade/references/api-traps.md
@@ -1,0 +1,155 @@
+# TYPO3 API Traps (Cross-Version)
+
+Architectural rules and silent footguns that bite across TYPO3 v12, v13, and v14. Each one looks innocuous at the call site but produces wrong-but-not-fatal behavior — soft-deleted records vanish, registrations get silently dropped, paths double, DI breaks at runtime.
+
+---
+
+## `Connection::select()` Applies TCA Restrictions Silently
+
+`TYPO3\CMS\Core\Database\Connection::select()` (the convenience wrapper, not the QueryBuilder fluent API) applies the **default `RestrictionContainer`**, which includes `DeletedRestriction`, `HiddenRestriction`, and `StartTimeRestriction` per TCA. Code reaching for "I just want to read the row" misses every soft-deleted / hidden / time-restricted record.
+
+This bites hardest in admin tooling, cleanup scripts, and audit features that explicitly want to see deleted records.
+
+**Search Pattern**
+
+```bash
+grep -rn "->select(\|Connection::select" Classes/
+```
+
+**Fix** — drop down to `QueryBuilder` and remove restrictions explicitly:
+
+```php
+// ❌ Silently filters deleted/hidden/time-restricted rows
+$rows = $connection->select(['*'], 'be_users', ['uid' => $uid])->fetchAllAssociative();
+
+// ✅ See every row, including deleted
+$queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+    ->getQueryBuilderForTable('be_users');
+$queryBuilder->getRestrictions()->removeAll();
+$rows = $queryBuilder
+    ->select('*')
+    ->from('be_users')
+    ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+    ->executeQuery()
+    ->fetchAllAssociative();
+```
+
+To keep some restrictions but drop others, use `removeByType(DeletedRestriction::class)` instead of `removeAll()`.
+
+---
+
+## `TYPO3_USER_SETTINGS` Registration MUST Live in `ext_tables.php`
+
+`cms-setup`'s own `ext_tables.php` rebuilds `$GLOBALS['TYPO3_USER_SETTINGS']` from scratch. Any field your extension registers in `ext_localconf.php` is wiped out before the setup module gets to read it — and the failure mode is silent: no error, the field just doesn't appear.
+
+**Affected**: any custom user-settings panel, e.g. an "Enable passkey login" toggle.
+
+**Symptom**: field renders during local dev (when caches are warm with stale data) but is missing on a fresh install / after `Flush all caches`.
+
+**Fix** — move the registration:
+
+```php
+// ❌ ext_localconf.php — silently overwritten
+ExtensionManagementUtility::addUserTSConfig(...);
+$GLOBALS['TYPO3_USER_SETTINGS']['columns']['tx_myext_setting'] = [...];
+
+// ✅ ext_tables.php — runs AFTER cms-setup/ext_tables.php
+$GLOBALS['TYPO3_USER_SETTINGS']['columns']['tx_myext_setting'] = [...];
+ExtensionManagementUtility::addFieldsToUserSettings('tx_myext_setting', 'after:lang');
+```
+
+See also: [TYPO3 boot order](#typo3-boot-order) below.
+
+---
+
+## TYPO3 Boot Order
+
+The reason for the rule above. Boot order is:
+
+1. `ext_localconf.php` of every active extension (in extension dependency order)
+2. TCA loaded
+3. `ext_tables.php` of every active extension (in extension dependency order)
+
+Anything that depends on **another extension's `ext_tables.php` having already executed** must itself live in `ext_tables.php`. The two most common cases:
+
+- **User Settings fields** — `cms-setup/ext_tables.php` overwrites `$GLOBALS['TYPO3_USER_SETTINGS']`
+- **Backend module overrides** — depend on `cms-backend` having registered the module first
+
+Mental model: `ext_localconf.php` is for "configure the framework" (DI, caches, hooks, event listeners). `ext_tables.php` is for "extend things the framework already built."
+
+---
+
+## `callUserFunction()` Bypasses Dependency Injection
+
+`GeneralUtility::callUserFunction()` instantiates the target class via `makeInstance()` **without DI**, calling the constructor with no arguments. Any class used as a userFunc target (TypoScript `userFunc`, TCA `displayCond`, custom hooks routed through callUserFunction, user-settings panels, etc.) **cannot use constructor injection** — you'll get a `TypeError: too few arguments`.
+
+**Search Pattern**
+
+```bash
+grep -rn "callUserFunction\|userFunc\s*=" Classes/ Configuration/
+```
+
+**Fix options** (in order of preference):
+
+```php
+// ❌ Constructor DI breaks under callUserFunction
+final class MyPanel
+{
+    public function __construct(private readonly LanguageService $lang) {}
+    public function render(array $params): string { ... }
+}
+```
+
+```php
+// ✅ Option 1 — pull deps via makeInstance() inside the method
+final class MyPanel
+{
+    public function render(array $params): string
+    {
+        $lang = GeneralUtility::makeInstance(LanguageServiceFactory::class)->createFromUserPreferences(...);
+        // ...
+    }
+}
+```
+
+```php
+// ✅ Option 2 — refactor away from callUserFunction
+//    For TCA displayCond: use the array-form `displayCond` instead of userFunc
+//    For TypoScript: use a USER content object pointing at a properly DI'd controller action
+//    For PSR-14 events: just write an event listener
+```
+
+PHPStan won't catch this — the class constructor is valid PHP. The error appears only when TYPO3 actually invokes the userFunc.
+
+---
+
+## `TemplatePaths::ensureAbsolutePath()` Resolves `EXT:` Paths Itself
+
+Fluid's `TYPO3Fluid\Fluid\View\TemplatePaths::ensureAbsolutePath()` (and the layers above it — `setTemplateRootPaths`, `setLayoutRootPaths`, `setPartialRootPaths`) accept `EXT:my_ext/Resources/Private/Templates/` directly and resolve it through `GeneralUtility::getFileAbsFileName()` internally.
+
+If you pre-resolve the path yourself with `GeneralUtility::getFileAbsFileName('EXT:my_ext/...')` and then pass the absolute result, **most setups still work** — but on Composer-mode installs where the EXT path resolves to a symlinked vendor directory, you can hit path-doubling (`/var/www/html/vendor/.../EXT:my_ext/...`) or stale resolution after a `composer dump-autoload`.
+
+**Fix** — pass `EXT:` paths verbatim:
+
+```php
+// ❌ Pre-resolved
+$view->setTemplateRootPaths([
+    GeneralUtility::getFileAbsFileName('EXT:my_ext/Resources/Private/Templates/'),
+]);
+
+// ✅ Let TemplatePaths resolve it
+$view->setTemplateRootPaths([
+    'EXT:my_ext/Resources/Private/Templates/',
+]);
+```
+
+Same applies to `LayoutRootPaths` and `PartialRootPaths`.
+
+---
+
+## See Also
+
+- `upgrade-v11-to-v12.md` — v12 FormEngine DI nodes (`setData()` workaround for [#100670](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100670-DIAwareFormEngineNodes.html))
+- `upgrade-v12-to-v13.md` — `#[AsEventListener]` v13+ vs `Services.yaml` tag for v12 compat
+- `upgrade-v13-to-v14.md` — `LoginProviderInterface::modifyView()`, `StandaloneView` removal, `ModifyPageLayoutOnLoginProviderSelectionEvent` signature drift
+- `api-changes.md` — full deprecated/removed API tables per version

--- a/skills/typo3-extension-upgrade/references/upgrade-v11-to-v12.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v11-to-v12.md
@@ -61,4 +61,44 @@ $rectorConfig->sets([
 }
 ```
 
+## v12-Specific Gotchas
+
+### FormEngine DI Nodes Need Their Own `setData()`
+
+> **Source**: [Deprecation #100670 — DI-aware FormEngine nodes](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100670-DIAwareFormEngineNodes.html)
+
+In v12, `AbstractNode::setData()` is **commented out** and the constructor-based `NodeFactory` invocation is the deprecated path. If your custom FormEngine element (`AbstractFormElement` subclass) uses constructor injection, `NodeFactory` falls back to the legacy `__construct(NodeFactory $nodeFactory, array $data)` path and you get:
+
+```
+TypeError: Argument #1 ($nodeFactory) of MyFormElement::__construct() must be of type NodeFactory, …
+```
+
+**Fix** (works on v12, v13, v14):
+
+```php
+final class MyFormElement extends AbstractFormElement
+{
+    public function __construct(
+        private readonly LanguageService $languageService,
+    ) {}
+
+    // REQUIRED on v12 — restored signature without NodeFactory
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    public function render(): array { /* ... */ }
+}
+```
+
+```yaml
+# Configuration/Services.yaml — MUST be public for makeInstance lookup
+services:
+  Vendor\MyExt\FormEngine\MyFormElement:
+    public: true
+```
+
+`#[Autoconfigure(public: true)]` on the class works too. Without `public: true`, the DI container won't resolve the class for `NodeFactory`'s lazy lookup and you fall back to the broken legacy path.
+
 See also: `api-changes.md` for detailed patterns.

--- a/skills/typo3-extension-upgrade/references/upgrade-v12-to-v13.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v12-to-v13.md
@@ -39,4 +39,34 @@ $rectorConfig->sets([
 | Frontend user | `$TSFE->fe_user` | `$request->getAttribute('frontend.user')` |
 | Page info | `$data['pObj']->rootLine` | `$request->getAttribute('frontend.page.information')` |
 
+## Dual v12 + v13 Gotchas
+
+### `#[AsEventListener]` Attribute Is v13+ Only
+
+The PHP attribute `#[AsEventListener]` was introduced in TYPO3 v13 (Symfony EventDispatcher attribute). If your extension supports `^12.4 || ^13.4 || ^14.0`, the attribute alone is **not enough** — on v12, the listener is never registered (silent: no error, the event simply never fires).
+
+**Fix**: keep BOTH the attribute AND the `Services.yaml` tag. v13+ ignores the tag when the attribute is present, so there is no double-registration.
+
+```php
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+#[AsEventListener(identifier: 'vendor-myext/login-listener')]
+final class LoginListener
+{
+    public function __invoke(BeforeUserLogoutEvent $event): void { /* ... */ }
+}
+```
+
+```yaml
+# Configuration/Services.yaml — required for v12 compat
+services:
+  Vendor\MyExt\EventListener\LoginListener:
+    tags:
+      - name: event.listener
+        identifier: 'vendor-myext/login-listener'
+        event: TYPO3\CMS\Core\Authentication\Event\BeforeUserLogoutEvent
+```
+
+**Drop the `Services.yaml` tag** only when bumping the floor to `^13.4`.
+
 See also: `api-changes.md` for detailed patterns.

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -182,6 +182,99 @@ The migration is safe across **v12.4 + v13.4 + v14.3** without compatibility shi
 
 ---
 
+## Expanded gotchas (v13 → v14)
+
+The table above is the index. The sections below expand the entries that have surprised real upgrades.
+
+### `LoginProviderInterface::modifyView()` — added in v14, two pitfalls
+
+v14 added `modifyView(ViewInterface $view, ServerRequestInterface $request): void` alongside `render()`. Two things bite:
+
+**1. The implementation must exist on v14, even if unused on v13.** Implementations conditional on a `class_exists()` check are too late — the interface contract is checked at class-load time. Just add the method and accept that v13 ignores it.
+
+**2. `modifyView()` returns the template name as a RELATIVE path, not an `EXT:` path.** Returning `'EXT:my_ext/Resources/Private/Templates/Login/PasskeyLogin.html'` results in Fluid trying to resolve it as a template **name** (no file found). Return `'Login/PasskeyLogin'` and register the extension's template root path on the view:
+
+```php
+public function modifyView(ServerRequestInterface $request, ViewInterface $view): string
+{
+    if ($view instanceof FluidViewAdapter) {
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateRootPaths([
+            'EXT:my_ext/Resources/Private/Templates/',
+        ]);
+    }
+    return 'Login/PasskeyLogin'; // relative, no .html, no EXT: prefix
+}
+```
+
+### `StandaloneView` removed — guard the test mocks too
+
+> **Breaking #105377** — already in the table above.
+
+The table covers production code. The hidden hit is in **tests**: `createMock(StandaloneView::class)` raises `Cannot use undefined class` when `StandaloneView` is missing under v14. Tests that need to run on the v12/v13/v14 matrix must guard:
+
+```php
+public function testRendersLoginScreen(): void
+{
+    if (!class_exists(\TYPO3\CMS\Fluid\View\StandaloneView::class)) {
+        self::markTestSkipped('StandaloneView removed in TYPO3 v14');
+    }
+    $view = $this->createMock(\TYPO3\CMS\Fluid\View\StandaloneView::class);
+    // ...
+}
+```
+
+This is also why `dg/bypass-finals` alone doesn't help — bypass-finals strips `final`, but it cannot conjure a class that no longer exists.
+
+### `ModifyPageLayoutOnLoginProviderSelectionEvent` — view parameter type drifts across versions
+
+The event's view parameter type changes per major:
+
+| TYPO3 | Type of `$view` |
+|---|---|
+| v12 | `StandaloneView` (concrete) |
+| v13 | `StandaloneView \| ViewInterface` (union) |
+| v14 | `ViewInterface` (StandaloneView removed) |
+
+Cross-version event-listener tests cannot just `createMock(ViewInterface::class)` — on v12 the constructor type-hint rejects it. Detect the parameter type via reflection and mock the right one:
+
+```php
+$rc = new \ReflectionClass(ModifyPageLayoutOnLoginProviderSelectionEvent::class);
+$paramType = $rc->getConstructor()->getParameters()[0]->getType();
+
+$mockTarget = match (true) {
+    $paramType instanceof \ReflectionUnionType,
+    $paramType?->getName() === StandaloneView::class
+        => StandaloneView::class,
+    default => ViewInterface::class,
+};
+$view = $this->createMock($mockTarget);
+```
+
+### PHPStan v14 without `saschaegerer/phpstan-typo3`
+
+`saschaegerer/phpstan-typo3` v2 supports v13 only — drop it on v12 **and** v14 CI runs. Without the extension, two ergonomic issues appear on the v14 build:
+
+1. `GeneralUtility::getIndpEnv()` returns a union type rather than the narrow `string` the extension would have inferred — assignments to `string` properties trigger `assign.propertyType` errors. Migrate to `NormalizedParams` (see "v14.x deprecations" above) or annotate the call site.
+2. Ignores written for v12 issues (e.g. `StandaloneView`, `Connection::PARAM_*` int-vs-enum) match nothing on v14 and trigger PHPStan's "ignored error not matched" warning.
+
+**Fix** in `Build/phpstan.neon`:
+
+```neon
+parameters:
+    # Don't fail on v12-only ignores when running against v14
+    reportUnmatchedIgnoredErrors: false
+
+    ignoreErrors:
+        # v12-only — Connection::PARAM_* is int there, ParameterType enum on v13/v14
+        - '~Parameter \\#2 \\$type of method .* expects .*, int given~'
+        # v14-only — getIndpEnv() returns union; remove once migrated to NormalizedParams
+        - '~Parameter .* of method .*::setRemoteAddress\(\) expects string, .* given~'
+```
+
+`phpstan/extension-installer` auto-loads any installed PHPStan extensions — once you remove `saschaegerer/phpstan-typo3` from the v12/v14 dev branches' `composer.json`, no manual `includes:` cleanup is needed.
+
+---
+
 ## Dual-version compatibility guards
 
 If supporting v13 + v14:


### PR DESCRIPTION
## Summary

Captures 11 cross-project TYPO3 v12-v14 compatibility lessons surfaced during the [nr_passkeys_be](https://github.com/netresearch/t3x-nr-passkeys-be) dual-version work. Each entry describes a *silent-failure* mode -- no exception, no log line, just wrong behaviour.

### New: `references/api-traps.md`

Five timeless TYPO3 architectural footguns that bite regardless of version transition:

- `Connection::select()` silently applies TCA `DeletedRestriction` -- soft-deleted rows vanish from admin tooling
- `TYPO3_USER_SETTINGS` registration **must** live in `ext_tables.php` (cms-setup's own `ext_tables.php` overwrites the global if you registered in `ext_localconf.php`)
- TYPO3 boot order: `ext_localconf.php` (all) -> TCA -> `ext_tables.php` (all) -- explains the rule above
- `callUserFunction()` bypasses constructor DI -- userFunc target classes can't use constructor injection
- `TemplatePaths::ensureAbsolutePath()` resolves `EXT:` itself; pre-resolving causes path-doubling on Composer-mode setups

### `references/upgrade-v11-to-v12.md`

- v12 FormEngine DI nodes ([Deprecation #100670](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100670-DIAwareFormEngineNodes.html)) -- `AbstractNode::setData()` is commented out in v12, so DI-using `AbstractFormElement` subclasses must declare their own `setData()` and be `public: true`

### `references/upgrade-v12-to-v13.md`

- `#[AsEventListener]` is v13+ only -- dual-compat extensions must keep BOTH the attribute AND the `Services.yaml` `event.listener` tag

### `references/upgrade-v13-to-v14.md`

Expands four entries the existing v14 index lists as one-liners:

- `LoginProviderInterface::modifyView()` -- (a) the method must exist on v14 even if conditional on `class_exists()` checks, (b) it must return a relative template name, NOT an `EXT:` path
- `StandaloneView` removal -- guard test mocks (`createMock(StandaloneView::class)`) with `class_exists()` skip
- `ModifyPageLayoutOnLoginProviderSelectionEvent` view-parameter type drifts across v12/v13/v14 -- detect via `ReflectionUnionType` for cross-version event-listener tests
- PHPStan v14 without `saschaegerer/phpstan-typo3` (v13-only) -- `getIndpEnv()` returns a union type, set `reportUnmatchedIgnoredErrors: false` so v12-only ignores don't break the v14 build

### Style

Mirrors the existing reference structure: Search Pattern (grep), Before/After fix blocks, Forge issue links where applicable, no prose-only sections.

## Test plan

- [ ] Skill validation CI (`Lint` workflow via `netresearch/skill-repo-skill/.github/workflows/validate.yml@main`) green
- [ ] No content overlap with the existing v14 table rows for `LoginProviderInterface::render() -> modifyView()` and `StandaloneView`/`TemplateView removed` (the table stays as the index; the new sections expand the angles -- tests, type drift -- not covered there)
- [ ] `references/api-traps.md` registered in `SKILL.md` references table
- [ ] All cross-references (`See also: ...`) resolve to existing files