### PR TITLE
feat: relocate SingletonInterface deprecation checkpoints (TU-54, TU-55)

### DIFF
--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -1,6 +1,10 @@
 # Checkpoints for typo3-extension-upgrade skill
 # Validates extension readiness for TYPO3 version upgrades
 
+# RELOCATED FROM php-modernization-skill (v1.16.0 refocus):
+#   PM-35 -> TU-54 (mechanical: SingletonInterface in Classes/src)
+#   PM-36 -> TU-55 (LLM: SingletonInterface migration to DI scoping)
+
 version: 1
 skill_id: typo3-extension-upgrade
 
@@ -317,6 +321,13 @@ mechanical:
     severity: warning
     desc: "Should not use deprecated TYPO3_REQUESTTYPE constant (use ApplicationType)"
 
+  # === SINGLETONINTERFACE DEPRECATION (TYPO3 v14) ===
+  - id: TU-54
+    type: command
+    command: "! grep -rql 'SingletonInterface' Classes/ src/ 2>/dev/null"
+    severity: warning
+    desc: "SingletonInterface is deprecated in TYPO3 v14. Migrate to proper DI scoping (Services.yaml shared: true) unless the class must be used with GeneralUtility::setSingletonInstance in tests."
+
 llm_reviews:
   # === COMPREHENSIVE RECTOR REVIEW ===
   - id: TU-40
@@ -563,3 +574,22 @@ llm_reviews:
       Report each incompatible mock with file:line and recommended fix.
     severity: error
     desc: "Test mocks must reference methods valid on interfaces in all supported dependency versions"
+
+  # === SINGLETONINTERFACE DEPRECATION (TYPO3 v14) ===
+  - id: TU-55
+    domain: code-quality
+    prompt: |
+      Review the codebase for uses of TYPO3\CMS\Core\SingletonInterface.
+
+      Check for:
+      1. Classes implementing SingletonInterface — this is deprecated in TYPO3 v14
+      2. Suggest migration to proper DI container scoping (shared: true in Services.yaml)
+      3. EXCEPTION: Classes that must be used with GeneralUtility::setSingletonInstance()
+         in test fixtures. These may need to keep the interface temporarily until
+         the test setup is refactored to use proper DI container overrides.
+      4. Check if the singleton behavior is actually needed or if the class can
+         simply be a regular shared service (which is the DI container default).
+
+      Report specific files implementing SingletonInterface and migration path.
+    severity: warning
+    desc: "SingletonInterface is deprecated in TYPO3 v14 — migrate to DI container scoping"

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -410,3 +410,12 @@ See also:
 - `third-party-dependency-upgrades.md` — Symfony 7.3 / Doctrine DBAL 4 / Fluid 5 / CKE 47 bump notes
 - `verification.md` — success criteria
 - TYPO3 Core Changelog 14.0–14.3: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-14.html
+
+## SingletonInterface deprecation (TYPO3 v14)
+
+`TYPO3\CMS\Core\SingletonInterface` is deprecated in v14. Code keeps working in v14.x, but every implementer needs a migration plan before v15. The replacement is the Symfony DI container's default behaviour: services declared in `Configuration/Services.yaml` are shared by default, so `shared: true` (or simply omitting `shared: false`) gives you the same one-instance-per-request semantics without the marker interface. Drop `implements SingletonInterface`, configure the service explicitly when its scope is non-trivial, and let the container manage the lifetime.
+
+The one common exception is classes registered through `GeneralUtility::setSingletonInstance()` in test fixtures — those rely on the static singleton registry, not the DI container, so the interface may need to stay until the test setup is refactored to use container overrides (`$this->getContainer()->set(...)` in functional tests, or proper service mocks in unit tests). The checkpoints surface this:
+
+- **TU-54** (mechanical) — flags any `SingletonInterface` reference under `Classes/` or `src/`.
+- **TU-55** (LLM review) — reviews each occurrence and proposes the DI-scoping migration, accounting for the test-fixture exception.


### PR DESCRIPTION
## Summary

Companion to [netresearch/php-modernization-skill#40](https://github.com/netresearch/php-modernization-skill/pull/40) (v1.16.0 agent-harness refocus). The TYPO3-v14 \`SingletonInterface\` deprecation checkpoints belong in \`typo3-extension-upgrade\`, not \`php-modernization\`, since they are explicitly an upgrade-time concern.

## Mapping

| Original | New | Type | Topic |
|---|---|---|---|
| PM-35 | **TU-54** | mechanical | grep for \`TYPO3\\CMS\\Core\\SingletonInterface\` in \`Classes/\` or \`src/\` |
| PM-36 | **TU-55** | llm_review | Migration to DI scoping (\`shared: true\`); AbstractTask + test-fixture exceptions |

Mechanical command adapted to support both archetypes (\`Classes/\` and \`src/\`) via dual-path scan. LLM-review prompt preserved verbatim including the test-fixture exception clause.

Both severity \`warning\`, both \`domain: code-quality\`.

## Documentation

\`references/upgrade-v13-to-v14.md\` gains a \"SingletonInterface deprecation\" section linking to TU-54/TU-55 with the migration rationale.

A relocation note at the top of \`checkpoints.yaml\` records the PM-XX → TU-XX mappings for traceability.

## Why this PR exists

The receiving repo, [\`netresearch/php-modernization-skill\`](https://github.com/netresearch/php-modernization-skill/pull/40), is being refocused as **pure PHP modernization** — PSR/PHP-FIG, PER-CS, PHP 8.x features. TYPO3-specific deprecations (SingletonInterface in v14) are upgrade-flow concerns; they belong here.

## Test plan

- [x] \`yaml.safe_load(checkpoints.yaml)\` parses cleanly
- [x] 58 total checkpoints, no duplicate IDs
- [x] TU-54 + TU-55 present
- [x] \`references/upgrade-v13-to-v14.md\` updated
- [ ] CI validation passes