### PR TITLE
fix(TU-54): use 'pattern:' key + dir-existence loop

### DIFF
--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -324,7 +324,7 @@ mechanical:
   # === SINGLETONINTERFACE DEPRECATION (TYPO3 v14) ===
   - id: TU-54
     type: command
-    command: "! grep -rql 'SingletonInterface' Classes/ src/ 2>/dev/null"
+    pattern: 'for d in Classes src; do [ -d "$d" ] && grep -rql "SingletonInterface" "$d" 2>/dev/null && exit 1; done; exit 0'
     severity: warning
     desc: "SingletonInterface is deprecated in TYPO3 v14. Migrate to proper DI scoping (Services.yaml shared: true) unless the class must be used with GeneralUtility::setSingletonInstance in tests."
 


### PR DESCRIPTION
## Summary

Addresses both Copilot review comments on the (now-merged) [#30](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/30) — the SingletonInterface deprecation relocation.

## Issue 1: wrong key for type:command

The skill schema in this repo uses \`pattern:\` for \`type: command\` checkpoints (see TU-02, TU-03, TU-05, TU-37, TU-60). TU-54 introduced \`command:\` which is **ignored by the runner** — silently making the checkpoint a no-op.

This is the OPPOSITE convention from \`php-modernization-skill\` (where \`type: command\` uses \`command:\`). I followed the wrong skill's schema by reflex.

## Issue 2: grep exit-code masking

The previous grep:
\`\`\`bash
! grep -rql 'SingletonInterface' Classes/ src/ 2>/dev/null
\`\`\`
returns exit code **2** when either \`Classes/\` or \`src/\` is missing (typical: extensions use one or the other, never both). With the leading \`!\`, that spurious error inverts to **pass**, masking real \`SingletonInterface\` matches in whichever directory does exist.

## Fix

Use the for-loop pattern already used elsewhere in this file (TU-02, TU-03):

\`\`\`bash
for d in Classes src; do
  [ -d \"\$d\" ] && grep -rql 'SingletonInterface' \"\$d\" 2>/dev/null && exit 1
done
exit 0
\`\`\`

Only greps directories that actually exist. Returns exit 1 if **any** existing directory contains \`SingletonInterface\`. Returns exit 0 only if no existing directory matches.

## Test plan

Smoke-tested locally against 4 scenarios (\`both\`, \`Classes only\`, \`src only\`, \`neither\`):

| Scenario | Expected | Actual |
|---|---|---|
| Both dirs contain SingletonInterface | FAIL (warn) | FAIL ✓ |
| Only \`Classes/\` contains it | FAIL (warn) | FAIL ✓ |
| Only \`src/\` contains it | FAIL (warn) | FAIL ✓ |
| Neither contains it (or dirs missing) | PASS | PASS ✓ |

YAML parses cleanly via \`yaml.safe_load\`. No other entries touched.

Resolves both Copilot threads on #30.