### PR TITLE
chore(release): v3.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",


### PR DESCRIPTION
## Release v3.7.0

Minor release. Bumps `.claude-plugin/plugin.json` from `3.6.2` to `3.7.0`. Picks up nineteen commits since `v3.6.1` covering cross-version Fluid/PHP guidance, getIndpEnv migration coverage, checkpoint relocation, and release-workflow hardening.

### Highlights since v3.6.1

- `getIndpEnv()` is documented as a v14.3 deprecation with the explicit NormalizedParams migration path so dual-version extensions stop carrying the legacy call shape.
- New cross-version reference material covers Fluid and PHP idioms that hold across v12/v13/v14, plus an `api-traps.md` collection of the most common pitfalls when widening composer constraints.
- SingletonInterface deprecation checkpoints have been relocated alongside the upgrade flow they actually belong to (TU-54, TU-55), and the pattern matcher now uses a `pattern:` key with a dir-existence loop for reliable detection.
- Release workflow gains SLSA provenance permissions, drops the deprecated `with:` block + `workflow_dispatch.bump` input, and acquires the trailing newline yamllint expects.
- SKILL.md description trimmed to fit the 500-word frontmatter ceiling.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
