### PR TITLE
chore(release): v3.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",


### PR DESCRIPTION
Release **v3.8.0** (minor bump, conventional commits since v3.7.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 3.8.0.

Changes since v3.7.0:
- feat: add .pre-commit-config.yaml mirroring CI checks
- 
- Wires netresearch/skill-repo-skill@v1.22.0 as a pre-commit hook
- provider so validate-skill, check-version-parity, and the standard
- linter set (markdownlint-cli2, yamllint, actionlint, ruff, shellcheck)
- run locally before commit instead of only in CI.
- 
- Part of the fleet rollout following netresearch/agent-harness-skill#27
- (CI/Hook Parity Principle) and skill-repo-skill v1.22.0 (hook exposure).
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- feat: add .pre-commit-config.yaml mirroring CI checks (#33)
- 
- ## Summary
- 
- Wires
- [`netresearch/skill-repo-skill@v1.22.0`](https://github.com/netresearch/skill-repo-skill/releases/tag/v1.22.0)
- as a pre-commit hook provider so `validate-skill`,
- `check-version-parity`, plus markdownlint-cli2 / yamllint / actionlint /
- ruff / shellcheck run locally before commit.

After merge: a signed tag `v3.8.0` on `main` triggers the release workflow.