### PR TITLE
feat: checkpoint Rector target version + audit-vs-fix ticketing guidance

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -31,6 +31,19 @@ Extension code only -- NOT for project/core upgrades.
 10. Test in target TYPO3 version(s)
 11. Verify success criteria (consult `references/verification.md`)
 
+## Audit mode: report vs. auto-fix
+
+When the goal is to **assess/report** (e.g. produce an upgrade estimate or file issues) rather than to apply the upgrade, do **not** create tickets for findings that the upgrade toolchain fixes automatically. Otherwise the backlog fills with noise.
+
+1. Pin the tool targets to the **upgrade target**, not the current state, before the dry-run:
+   - Rector: `Typo3LevelSetList::UP_TO_TYPO3_<target>` and `LevelSetList::UP_TO_PHP_<ceiling>` (a stale config silently skips the relevant migrations — see checkpoints TU-56/TU-57).
+   - PHPStan: set `phpVersion: { min: <floor>, max: <ceiling> }` to verify the whole supported PHP range (e.g. 8.2–8.5).
+2. Run `rector process --dry-run` and `fractor process --dry-run`; collect the **applied rules**.
+3. Run `phpstan analyse` with deprecation rules; collect the **deprecation findings**.
+4. **Cross-reference**: a PHPStan deprecation that has a matching Rector/Fractor rule is **auto-fixed on upgrade → do not ticket**. Only deprecations/findings **without** a matching rule need manual work → ticket those (plus logic bugs, design gaps, and config the tools skip such as `ext_emconf.php`).
+
+Ignore pure code-style rules (e.g. `ClassPropertyAssignToConstructorPromotionRector`) when deciding what is upgrade-relevant.
+
 ## When NOT to Apply Automatically
 
 Do NOT blindly apply Rector/Fractor if dual-version compatibility is needed,

--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -50,6 +50,18 @@ mechanical:
     severity: info
     desc: "Fractor config should use TYPO3 level sets"
 
+  - id: TU-56
+    type: command
+    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -q "UP_TO_TYPO3_14" "$cfg" && exit 0; grep -qE "UP_TO_TYPO3_1[0-3]" "$cfg" && exit 1; exit 0'
+    severity: warning
+    desc: "Rector Typo3LevelSetList should target the current LTS (UP_TO_TYPO3_14) — a stale set (e.g. UP_TO_TYPO3_13) passes TU-02 but silently skips all v14 migrations during the dry-run"
+
+  - id: TU-57
+    type: command
+    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -qE "UP_TO_PHP_8[456]" "$cfg" && exit 0; grep -qE "UP_TO_PHP_8[0-3]" "$cfg" && exit 1; exit 0'
+    severity: info
+    desc: "Rector PHP LevelSetList should target the supported PHP ceiling (UP_TO_PHP_84/85) so version-specific deprecations (implicit-nullable 8.4+, 8.5 changes) are caught"
+
   # === COMPOSER.JSON VERSION CONSTRAINTS ===
   - id: TU-06
     type: json_path


### PR DESCRIPTION
## Why
While auditing an extension for the **v13 → v14** upgrade, the extension's `rector.php` still targeted `Typo3LevelSetList::UP_TO_TYPO3_13`. Checkpoint **TU-02** (rector uses a `Typo3LevelSetList`) passed — but the dry-run silently skipped **all** v14 migrations, so the assessment looked cleaner than reality. The same happened on the PHP axis (a dependency targeting `UP_TO_PHP_82` with PHPStan having no `phpVersion`, so 8.5-specific deprecations were never checked).

## What
**Two new mechanical checkpoints** (rector config section):
- **TU-56** (`warning`): rector `Typo3LevelSetList` should target the current LTS `UP_TO_TYPO3_14`; warns on a stale pre-v14 set. Passes when no rector config exists (TU-01 covers existence) or when already on v14.
- **TU-57** (`info`): rector PHP `LevelSetList` should target the supported ceiling (`UP_TO_PHP_84/85`) so 8.4/8.5-specific deprecations (implicit-nullable, etc.) are caught.

**SKILL.md** — new section *“Audit mode: report vs. auto-fix”*:
- Pin tool targets to the **upgrade target** before the dry-run (Rector level sets, PHPStan `phpVersion` range).
- Cross-reference PHPStan deprecations against the **applied** Rector/Fractor rules; a deprecation with a matching rule is auto-fixed on upgrade → **do not ticket**. Only the non-automatable findings (plus logic bugs, design gaps, `ext_emconf.php` constraint that the tools skip) need manual work.
- Ignore pure code-style rules when deciding upgrade relevance.

## Verification
- `checkpoints.yaml` parses as valid YAML; IDs unique.
- TU-56 logic tested: v13 config → fail/warn; v14 config → pass; no config → pass.

Source: session retrospective (`/coach:retro`) from a real v14 extension + SDK upgrade audit.