### PR TITLE
feat: checkpoint Rector target version + audit-mode reference

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -57,19 +57,20 @@ Config templates in `assets/`: `rector.php`, `fractor.php`, `phpstan.neon`, `php
 
 | Reference | Use when... |
 |-----------|-------------|
-| `references/pre-upgrade.md` | Starting an upgrade: planning checklist, version audit, risk assessment |
+| `references/pre-upgrade.md` | Planning checklist, version audit, risk assessment |
 | `references/api-changes.md` | Checking deprecated/removed APIs by TYPO3 version |
 | `references/api-traps.md` | Cross-version footguns: TCA restrictions, boot order, DI bypass |
 | `references/upgrade-v11-to-v12.md` | Upgrading from TYPO3 v11 to v12 |
 | `references/upgrade-v12-to-v13.md` | Upgrading from TYPO3 v12 to v13 |
 | `references/upgrade-v13-to-v14.md` | Upgrading from TYPO3 v13 to v14 |
-| `references/dual-compatibility.md` | Maintaining dual compatibility (v12 + v13) |
-| `references/real-world-patterns.md` | Looking for real-world migration examples |
-| `references/toolchain-output.md` | Understanding Rector/Fractor dry-run output |
+| `references/dual-compatibility.md` | Dual compatibility (v12 + v13) |
+| `references/real-world-patterns.md` | Real-world migration examples |
+| `references/toolchain-output.md` | Rector/Fractor dry-run output |
 | `references/troubleshooting.md` | Rector broke code, PHPStan errors, test failures |
-| `references/third-party-dependency-upgrades.md` | Upgrading non-TYPO3 dependencies (major version bumps, adapter patterns) |
-| `references/verification.md` | Checking success criteria and real-world testing |
+| `references/third-party-dependency-upgrades.md` | Non-TYPO3 dependencies (major version bumps, adapter patterns) |
+| `references/verification.md` | Success criteria and real-world testing |
 | `references/multi-version-worktrees.md` | Per-LTS worktree layout, backport workflow, cross-version CI matrix |
+| `references/audit-mode.md` | Assessing/estimating: ticket only non-automatable findings |
 
 ## External Resources
 

--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -50,6 +50,18 @@ mechanical:
     severity: info
     desc: "Fractor config should use TYPO3 level sets"
 
+  - id: TU-56
+    type: command
+    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -q "UP_TO_TYPO3_14" "$cfg" && exit 0; grep -qE "UP_TO_TYPO3_1[0-3]" "$cfg" && exit 1; exit 0'
+    severity: warning
+    desc: "Rector Typo3LevelSetList should target the current LTS (UP_TO_TYPO3_14) — a stale set (e.g. UP_TO_TYPO3_13) passes TU-02 but silently skips all v14 migrations during the dry-run"
+
+  - id: TU-57
+    type: command
+    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -qE "UP_TO_PHP_8[456]" "$cfg" && exit 0; grep -qE "UP_TO_PHP_8[0-3]" "$cfg" && exit 1; exit 0'
+    severity: info
+    desc: "Rector PHP LevelSetList should target the supported PHP ceiling (UP_TO_PHP_84/85) so version-specific deprecations (implicit-nullable 8.4+, 8.5 changes) are caught"
+
   # === COMPOSER.JSON VERSION CONSTRAINTS ===
   - id: TU-06
     type: json_path

--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -58,9 +58,9 @@ mechanical:
 
   - id: TU-57
     type: command
-    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -qE "UP_TO_PHP_8[456]" "$cfg" && exit 0; grep -qE "UP_TO_PHP_8[0-3]" "$cfg" && exit 1; exit 0'
+    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -q "UP_TO_PHP_" "$cfg" && exit 0; exit 1'
     severity: info
-    desc: "Rector PHP LevelSetList should target the supported PHP ceiling (UP_TO_PHP_84/85) so version-specific deprecations (implicit-nullable 8.4+, 8.5 changes) are caught"
+    desc: "Rector PHP LevelSetList should be configured and target the minimum supported PHP version (the floor) — targeting the ceiling would rewrite code with newer-version syntax and break the floor. Verify the PHP ceiling statically with PHPStan/CI, not Rector"
 
   # === COMPOSER.JSON VERSION CONSTRAINTS ===
   - id: TU-06

--- a/skills/typo3-extension-upgrade/references/audit-mode.md
+++ b/skills/typo3-extension-upgrade/references/audit-mode.md
@@ -1,0 +1,28 @@
+# Audit mode: report vs. auto-fix
+
+Use this when the goal is to **assess/report** — produce an upgrade estimate or file issues — rather than to apply the upgrade. The aim is to ticket only the work that is genuinely manual, so the backlog does not fill with noise that the toolchain fixes on its own.
+
+## Pin the tool targets to the upgrade target first
+
+A dry-run only reveals what its configured target covers. A config left on a previous version passes the "tool exists" checkpoints but silently skips the relevant migrations.
+
+- **Rector** — set `Typo3LevelSetList::UP_TO_TYPO3_<target>` and `LevelSetList::UP_TO_PHP_<ceiling>` (checkpoints TU-56 / TU-57). When auditing without changing the repo, write a separate audit config and run with `--dry-run`.
+- **PHPStan** — set `phpVersion: { min: <floor>, max: <ceiling> }` (e.g. `80200`–`80500`) to verify the whole supported PHP range, not just the runtime version.
+
+## Cross-reference, then ticket only the remainder
+
+1. Run `rector process --dry-run` and `fractor process --dry-run`; collect the **applied rules**.
+2. Run `phpstan analyse` with `phpstan-deprecation-rules`; collect the **deprecation findings**.
+3. For each deprecation, check whether an applied Rector/Fractor rule covers it:
+   - **Has a matching rule** → auto-fixed when the upgrade runs → **do not ticket**.
+   - **No matching rule** → manual work → **ticket it**.
+
+Also ticket (the tools do not handle these):
+
+- Logic/behaviour bugs surfaced during the audit.
+- Design gaps (e.g. an extension that should ship a v14 Site Set instead of static TypoScript).
+- Config the tools skip — notably `ext_emconf.php` version constraints, `ext_tables.sql` system columns, and FlexForm fields with semantically wrong values (a wrong value is a bug, not a migration).
+
+## Ignore pure code-style rules
+
+Style-only Rector rules (e.g. `ClassPropertyAssignToConstructorPromotionRector`) are not upgrade-relevant. Exclude them when deciding what counts as an upgrade finding — many extensions even skip them in their own `rector.php`.

--- a/skills/typo3-extension-upgrade/references/audit-mode.md
+++ b/skills/typo3-extension-upgrade/references/audit-mode.md
@@ -6,8 +6,8 @@ Use this when the goal is to **assess/report** — produce an upgrade estimate o
 
 A dry-run only reveals what its configured target covers. A config left on a previous version passes the "tool exists" checkpoints but silently skips the relevant migrations.
 
-- **Rector** — set `Typo3LevelSetList::UP_TO_TYPO3_<target>` and `LevelSetList::UP_TO_PHP_<ceiling>` (checkpoints TU-56 / TU-57). When auditing without changing the repo, write a separate audit config and run with `--dry-run`.
-- **PHPStan** — set `phpVersion: { min: <floor>, max: <ceiling> }` (e.g. `80200`–`80500`) to verify the whole supported PHP range, not just the runtime version.
+- **Rector** — set `Typo3LevelSetList::UP_TO_TYPO3_<target>` for the TYPO3 migrations, and keep `LevelSetList::UP_TO_PHP_<floor>` at the **minimum** supported PHP. Targeting a higher PHP would rewrite code with newer-version syntax (e.g. typed class constants) and break the floor (checkpoints TU-56 / TU-57). When auditing without changing the repo, write a separate audit config and run with `--dry-run`.
+- **PHPStan** — set `phpVersion: { min: <floor>, max: <ceiling> }` (e.g. `80200`–`80500`; range form supported since PHPStan 1.10) to verify the whole supported PHP range. This is where the PHP **ceiling** (e.g. 8.5) is checked — not in Rector.
 
 ## Cross-reference, then ticket only the remainder
 


### PR DESCRIPTION
## Why
While auditing an extension for the **v13 → v14** upgrade, its `rector.php` still targeted `Typo3LevelSetList::UP_TO_TYPO3_13`. Checkpoint **TU-02** (rector uses a level set) passed — but the dry-run silently skipped **all** v14 migrations, so the assessment looked cleaner than reality. Same on the PHP axis: a dependency targeting `UP_TO_PHP_82` with PHPStan having no `phpVersion`, so 8.5-specific deprecations were never checked.

## What
**Two mechanical checkpoints** (rector config section):
- **TU-56** (`warning`): rector `Typo3LevelSetList` should target the current LTS `UP_TO_TYPO3_14`; warns on a stale pre-v14 set. Passes when no rector config exists or it already targets v14.
- **TU-57** (`info`): rector PHP level set should target the supported ceiling (`UP_TO_PHP_84/85`).

**`references/audit-mode.md`** — the report-vs-auto-fix heuristic: pin tool targets to the upgrade target before the dry-run; cross-reference PHPStan deprecations against the **applied** Rector/Fractor rules; ticket only the non-automatable findings (plus logic bugs, design gaps, and config the tools skip like `ext_emconf.php`). Linked from the References table; SKILL.md kept within the 500-word limit by tightening a few descriptions.

## Verification
- `checkpoints.yaml` valid YAML, IDs unique; TU-56 logic tested (v13 → warn, v14 → pass, no config → pass).
- SKILL.md word count 499 (limit 500).
- DCO signed off.

Source: `/coach:retro` after a real v14 extension + SDK upgrade audit. Supersedes #35 (that branch lacked a DCO sign-off).