### PR TITLE
chore(release): v3.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",


### PR DESCRIPTION
Release v3.9.0 — bumps `.claude-plugin/plugin.json` to 3.9.0.

Contains the changes merged in #36 (only change since v3.8.0):
- **TU-56** — warn when Rector targets a pre-v14 TYPO3 level set
- **TU-57** — ensure a Rector PHP level set is configured (target the floor; ceiling verified via PHPStan/CI)
- **references/audit-mode.md** — report-vs-auto-fix heuristic: ticket only non-automatable findings

Minor bump (new features, no breaking changes). After merge, tag `v3.9.0` triggers the release workflow.