### PR TITLE
docs(api-changes): cross-link canonical v14 facts, add deprecation scanner

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -5,8 +5,8 @@ description: "Use when upgrading TYPO3 extensions to newer LTS versions (v11->v1
 
 # TYPO3 Extension Upgrade Skill
 
-Systematic framework for upgrading TYPO3 extensions to newer LTS versions.
-Extension code only -- NOT for project/core upgrades.
+Framework for upgrading TYPO3 extensions to newer LTS versions.
+Extension code only, not project/core upgrades.
 
 ## Upgrade Toolkit
 
@@ -33,13 +33,13 @@ Extension code only -- NOT for project/core upgrades.
 
 ## When NOT to Apply Automatically
 
-Do NOT blindly apply Rector/Fractor if dual-version compatibility is needed,
-tests are missing, changes are unclear, or complex APIs (DBAL, Extbase) are
-affected. Instead: apply specific rules manually, test between each change.
+Do NOT blindly apply Rector/Fractor when dual-version compatibility, missing
+tests, unclear changes, or complex APIs (DBAL, Extbase) are involved. Instead
+apply rules manually, testing between changes.
 
 ## Third-Party Dependency Upgrades
 
-When `composer.json` widens constraints to a new major version: enumerate API usages, cross-reference the new version's API, flag interface/concrete-only methods, verify mocks against all supported versions, use adapter pattern for signature differences, run PHPStan against each major version. See `references/third-party-dependency-upgrades.md`.
+When `composer.json` widens a dependency to a new major version: enumerate API usages, cross-reference the new API, verify mocks, use adapter pattern for signature differences, run PHPStan per major version. See `references/third-party-dependency-upgrades.md`.
 
 ## Quick Commands
 
@@ -71,6 +71,7 @@ Config templates in `assets/`: `rector.php`, `fractor.php`, `phpstan.neon`, `php
 | `references/verification.md` | Success criteria and real-world testing |
 | `references/multi-version-worktrees.md` | Per-LTS worktree layout, backport workflow, cross-version CI matrix |
 | `references/audit-mode.md` | Assessing/estimating: ticket only non-automatable findings |
+| `scripts/scan-deprecations.sh <path>` | Deterministic grep scan for deprecated/removed APIs and traps |
 
 ## External Resources
 

--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -435,6 +435,8 @@ grep -rn "BackendUtility::wrapClickMenuOnIcon\|getClickMenuOnIconTagParameters" 
 
 ## v12 → v13 Upgrade
 
+The `$TSFE` properties deprecated below are fully removed in v14.0 — see typo3-conformance's canonical [`v14-deprecations.md`](https://github.com/netresearch/typo3-conformance-skill/blob/main/skills/typo3-conformance/references/v14-deprecations.md) §1.3 (`TypoScriptFrontendController` removal, #107831) for the removal fact. This section keeps the v13 migration execution: search patterns and fix code.
+
 ### Request Attributes (Critical)
 
 **Search Pattern**
@@ -490,9 +492,11 @@ grep -rn "'type'\s*=>\s*'text'" Configuration/TCA/
 
 ## v13 → v14 Upgrade
 
+For the full v14 removal and deprecation fact catalog, see typo3-conformance's canonical [`v14-deprecations.md`](https://github.com/netresearch/typo3-conformance-skill/blob/main/skills/typo3-conformance/references/v14-deprecations.md). This section keeps upgrade execution: search patterns and fix code.
+
 ### TypoScript/TSconfig Callables Require #[AsAllowedCallable] Attribute (Critical)
 
-> **Breaking: #108054** - [Changelog](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108054-EnforceExplicitOpt-inForTypoScriptTSconfigCallables.html)
+> **Breaking: #108054** - [Changelog](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108054-EnforceExplicitOpt-inForTypoScriptTSconfigCallables.html) · canonical fact: v14-deprecations.md §1.9
 
 TYPO3 v14 requires explicit opt-in for methods callable through TypoScript/TSconfig. Without the attribute, calls fail with `AllowedCallableException`.
 
@@ -571,6 +575,8 @@ if ($type instanceof StringType || $type instanceof TextType) { }
 ```
 
 ### Icon::SIZE_* Constants Replaced with IconSize Enum
+
+**Removed in v14.0** (canonical fact: v14-deprecations.md §1.2).
 
 **Search Pattern**
 ```bash
@@ -729,6 +735,8 @@ $icon = $iconFactory->getIcon('actions-edit', 'small');
 
 ### GeneralUtility::getIndpEnv() Deprecated -- Use NormalizedParams (v14.3)
 
+> **Canonical fact entry**: v14-deprecations.md §2.4 `#109551`.
+
 > **Deprecated: v14.3, scheduled for removal in v15.0**
 > **Source**: `typo3/cms-core` v14.3.0 vendor source, `Classes/Utility/GeneralUtility.php` (the `@deprecated` tag is on the method itself).
 > **Verify locally**: `grep -n -B5 "function getIndpEnv(" vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php` -- shows the docblock with `@deprecated since TYPO3 v14.3, will be removed in TYPO3 v15.0` directly above the method signature (line ~2142 in v14.3.0).
@@ -807,15 +815,7 @@ The migration is safe across the entire supported range with **no compatibility 
 
 ### Additional v14 Changes
 
-Monitor [Changelog-14](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-14.html) for additional breaking changes.
-
-**Known Removals**
-- `ExtensionConfiguration::getAll()` - use `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']`
-- `Type::getName()` in Doctrine DBAL - use `instanceof` checks
-- `Icon::SIZE_*` constants - use `IconSize` enum
-
-**Known Deprecations (v14.3, removal in v15.0)**
-- `GeneralUtility::getIndpEnv()` - use `NormalizedParams` from PSR-7 request
+For the complete v14 removal and deprecation catalog beyond the migration recipes above, see typo3-conformance's canonical `v14-deprecations.md`. Monitor [Changelog-14](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-14.html) for changes not yet catalogued.
 
 ---
 

--- a/skills/typo3-extension-upgrade/scripts/scan-deprecations.sh
+++ b/skills/typo3-extension-upgrade/scripts/scan-deprecations.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# scan-deprecations.sh - deterministic grep scan for TYPO3 API deprecations/removals
+#
+# Mirrors every "Search Pattern" grep recipe documented in references/api-changes.md
+# (v7->v8 through v13->v14, PHP 8.4, PSR-7, SC_OPTIONS) and the two architectural-trap
+# recipes in references/api-traps.md. This skill owns upgrade-execution detection; the
+# underlying v13/v14 breaking-change FACTS are canonical in typo3-conformance's
+# references/v14-deprecations.md.
+#
+# Usage: scripts/scan-deprecations.sh <path>
+#   <path>  extension root to scan (contains Classes/, Configuration/, Resources/, ...)
+#
+# Exit: 0 always (report-only; findings are informational, not pass/fail).
+
+set -euo pipefail
+
+target="${1:-.}"
+
+if [[ ! -d "$target" ]]; then
+    echo "error: path not found: $target" >&2
+    exit 1
+fi
+
+findings=0
+
+check_00() {
+    grep -rn "\$GLOBALS\['TYPO3_DB'\]\|exec_SELECTquery\|exec_INSERTquery\|exec_UPDATEquery\|exec_DELETEquery" "$target/Classes/"
+}
+
+check_01() {
+    grep -rn "Ext\.onReady\|new Ext\.\|Prototype\.\|Element\.extend" "$target/Resources/"
+}
+
+check_02() {
+    grep -rn "IconUtility::\|t3skin\|t3lib_iconWorks" "$target/Classes/"
+}
+
+check_03() {
+    grep -rn "sys_domain\|config\.baseURL\|absRefPrefix\s*=\s*auto" "$target/Configuration/"
+}
+
+check_04() {
+    grep -rn "AbstractUserAuthentication\|tslib_fe\|tslib_cObj" "$target/Classes/"
+}
+
+check_05() {
+    grep -rn "tx_realurl\|cooluri\|simulatestatic" "$target/Configuration/"
+}
+
+check_06() {
+    grep -rn "SignalSlotDispatcher\|->connect\(" "$target/Classes/"
+}
+
+check_07() {
+    grep -rn "Symfony\\\\Component\\\\Console\\\\Command\|setDescription\|setHelp" "$target/Classes/Command/"
+}
+
+check_08() {
+    grep -rn "GeneralUtility::makeInstance\|ObjectManager::get" "$target/Classes/"
+}
+
+check_09() {
+    grep -rn "SignalSlotDispatcher\|->emit\|->connect\(" "$target/Classes/"
+}
+
+check_10() {
+    grep -rn "{namespace\|xmlns:f=" "$target/Resources/Private/"
+}
+
+check_11() {
+    grep -rn "TYPO3Fluid\|StandaloneView\|setTemplatePathAndFilename" "$target/Classes/"
+}
+
+check_12() {
+    grep -rn "extends ActionController\|AbstractModule" "$target/Classes/Controller/"
+}
+
+check_13() {
+    grep -rn "'wizards'\s*=>\|'wizard_'" "$target/Configuration/TCA/"
+}
+
+check_14() {
+    grep -rn "PDO::PARAM_" "$target/Classes/"
+}
+
+check_15() {
+    grep -rn "->execute()" "$target/Classes/"
+}
+
+check_16() {
+    grep -rn "GeneralUtility::_GET\|GeneralUtility::_POST\|GeneralUtility::_GP" "$target/Classes/"
+}
+
+check_17() {
+    grep -rn "'eval'.*'required'" "$target/Configuration/TCA/"
+}
+
+check_18() {
+    grep -rn "'renderType' => 'inputLink'" "$target/Configuration/TCA/"
+}
+
+check_19() {
+    grep -rn "itemFormElID" "$target/Classes/"
+}
+
+check_20() {
+    grep -rn "xml2array" "$target/Classes/"
+}
+
+check_21() {
+    grep -rn "<required>1</required>" "$target/Configuration/FlexForms/"
+}
+
+check_22() {
+    grep -rn "\[end\]" "$target/Configuration/TypoScript/"
+}
+
+check_23() {
+    grep -rn "BackendUtility::wrapClickMenuOnIcon\|getClickMenuOnIconTagParameters" "$target/Classes/"
+}
+
+check_24() {
+    grep -rn "\$TSFE->fe_user\|\$GLOBALS\['TSFE'\]->fe_user" "$target/Classes/"
+}
+
+check_25() {
+    grep -rn "ext_typoscript_setup\.typoscript\|ext_typoscript_constants" "$target"
+}
+
+check_26() {
+    grep -rn "registerModule\|TYPO3_MOD_PATH" "$target/ext_tables.php"
+}
+
+check_27() {
+    grep -rn "'type'\s*=>\s*'text'" "$target/Configuration/TCA/"
+}
+
+check_28() {
+    # Find TypoScript userFunc references
+    grep -rn "userFunc\|preUserFunc\|postUserFunc" "$target/Configuration/TypoScript/"
+    # Find PHP classes referenced in TypoScript
+    grep -rn "->render\|->process" "$target/Configuration/TypoScript/" | grep -v "#"
+}
+
+check_29() {
+    grep -rn "ExtensionConfiguration::getAll\|->getAll()" "$target/Classes/"
+}
+
+check_30() {
+    grep -rn "->getName()\|Type::getName" "$target/Classes/"
+}
+
+check_31() {
+    grep -rn "Icon::SIZE_SMALL\|Icon::SIZE_DEFAULT\|Icon::SIZE_MEDIUM\|Icon::SIZE_LARGE" "$target/Classes/"
+}
+
+check_32() {
+    grep -rn "f:uri.resource\|<f:uri.resource" "$target/Resources/Private/"
+}
+
+check_33() {
+    grep -rn "AdditionalFieldProviderInterface\|getAdditionalFields" "$target/Classes/Task/"
+}
+
+check_34() {
+    grep -rn "btn-default\|badge-primary\|badge-success\|badge-danger\|badge-warning\|badge-info" "$target/Resources/"
+}
+
+check_35() {
+    grep -rn "\['config'\]\['type'\]" "$target/Classes/Hook/"
+}
+
+check_36() {
+    grep -rn "role=\"main\"\|aria-label\|aria-describedby" "$target/Resources/Private/"
+}
+
+check_37() {
+    grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" "$target/Classes/" "$target/Configuration/"
+}
+
+check_38() {
+    # Find parameters with null default but no explicit nullable type
+    grep -rn '\(.*\$[a-zA-Z_]* = null\)' "$target/Classes/" | grep -v '?[a-zA-Z_\\]*\s*\$'
+}
+
+check_39() {
+    grep -rn "'items'\s*=>\s*\[" "$target/Configuration/TCA/" | grep -v "label"
+}
+
+check_40() {
+    grep -rn "\$_GET\['\|\$_POST\['" "$target/Classes/"
+}
+
+check_41() {
+    grep -rn "SC_OPTIONS\['t3lib/class.t3lib_page.php'\]" "$target/ext_localconf.php"
+    grep -rn "additionalQueryRestrictions" "$target/ext_localconf.php"
+}
+
+check_42() {
+    grep -rn "PropertyInfo\\Type\|Type::BUILTIN_TYPE_" "$target/Classes/"
+}
+
+check_43() {
+    grep -rn "->select(\|Connection::select" "$target/Classes"
+}
+
+check_44() {
+    grep -rn "callUserFunction\|userFunc\s*=" "$target/Classes" "$target/Configuration"
+}
+
+labels=(
+    "v7 → v8 Upgrade: Database Layer: TYPO3_DB → Doctrine DBAL"
+    "v7 → v8 Upgrade: ExtJS/Prototype Removal"
+    "v7 → v8 Upgrade: Icon Factory"
+    "v8 → v9 Upgrade: Site Configuration Introduction"
+    "v8 → v9 Upgrade: PSR-15 Middleware"
+    "v8 → v9 Upgrade: Routing API"
+    "v8 → v9 Upgrade: Signal/Slot Deprecation Start"
+    "v9 → v10 Upgrade: Symfony 5 Upgrade"
+    "v9 → v10 Upgrade: Dependency Injection"
+    "v9 → v10 Upgrade: PSR-14 Events"
+    "v9 → v10 Upgrade: Fluid Namespace"
+    "v10 → v11 Upgrade: Fluid Standalone"
+    "v10 → v11 Upgrade: Backend Controller Changes"
+    "v10 → v11 Upgrade: TCA Wizard Changes"
+    "v11 → v12 Upgrade: Doctrine DBAL 4.x (Critical)"
+    "v11 → v12 Upgrade: Doctrine DBAL 4.x (Critical)"
+    "v11 → v12 Upgrade: GeneralUtility Deprecated Methods"
+    "v11 → v12 Upgrade: TCA Required Field"
+    "v11 → v12 Upgrade: TCA inputLink → type=link"
+    "v11 → v12 Upgrade: Form Element Data Structure"
+    "v11 → v12 Upgrade: xml2array Null Handling"
+    "v11 → v12 Upgrade: FlexForm Structure (Fractor handles)"
+    "v11 → v12 Upgrade: TypoScript Conditions"
+    "v11 → v12 Upgrade: Click Menu Parameters"
+    "v12 → v13 Upgrade: Request Attributes (Critical)"
+    "v12 → v13 Upgrade: Site Sets Introduction"
+    "v12 → v13 Upgrade: Backend Module Registration"
+    "v12 → v13 Upgrade: TCA Type Changes"
+    "v13 → v14 Upgrade: TypoScript/TSconfig Callables Require #[AsAllowedCallable] Attribute (Critical)"
+    "v13 → v14 Upgrade: ExtensionConfiguration::getAll() Removed (Critical)"
+    "v13 → v14 Upgrade: Doctrine DBAL 4.x Type::getName() Removed"
+    "v13 → v14 Upgrade: Icon::SIZE_* Constants Replaced with IconSize Enum"
+    "v13 → v14 Upgrade: f:uri.resource Not Available in Non-Extbase Modules"
+    "v13 → v14 Upgrade: Scheduler Interface Signature Changes"
+    "v13 → v14 Upgrade: Bootstrap 5 CSS Class Changes"
+    "v13 → v14 Upgrade: TCA renderType vs type"
+    "v13 → v14 Upgrade: ARIA Accessibility Requirements"
+    "v13 → v14 Upgrade: GeneralUtility::getIndpEnv() Deprecated -- Use NormalizedParams (v14.3)"
+    "PHP 8.4 Compatibility: Implicit Nullable Parameters (Critical)"
+    "PHP 8.4 Compatibility: TCA Items Array Format"
+    "PSR-7 Request Handling Patterns: Query Parameter Access in Context Classes"
+    "SC_OPTIONS Hooks to PSR-14 Events: Page Visibility Hooks (Critical for v12+)"
+    "Symfony Component Deprecations: PropertyInfo Type Class (Symfony 7.3+)"
+    "api-traps.md: Connection::select() applies TCA restrictions silently"
+    "api-traps.md: callUserFunction() bypasses Dependency Injection"
+)
+
+fns=(
+    check_00
+    check_01
+    check_02
+    check_03
+    check_04
+    check_05
+    check_06
+    check_07
+    check_08
+    check_09
+    check_10
+    check_11
+    check_12
+    check_13
+    check_14
+    check_15
+    check_16
+    check_17
+    check_18
+    check_19
+    check_20
+    check_21
+    check_22
+    check_23
+    check_24
+    check_25
+    check_26
+    check_27
+    check_28
+    check_29
+    check_30
+    check_31
+    check_32
+    check_33
+    check_34
+    check_35
+    check_36
+    check_37
+    check_38
+    check_39
+    check_40
+    check_41
+    check_42
+    check_43
+    check_44
+)
+
+for i in "${!fns[@]}"; do
+    fn="${fns[$i]}"
+    label="${labels[$i]}"
+    out=$("$fn" 2>/dev/null || true)
+    if [[ -n "$out" ]]; then
+        echo "=== $label ==="
+        echo "$out"
+        echo
+        findings=$((findings + 1))
+    fi
+done
+
+if [[ "$findings" -eq 0 ]]; then
+    echo "No matches for any documented deprecation/removal/trap pattern."
+else
+    echo "$findings pattern group(s) matched -- cross-check against"
+    echo "references/api-changes.md and typo3-conformance's v14-deprecations.md"
+    echo "before treating a match as a required fix. Some patterns (e.g. PHP 8.4"
+    echo "implicit-nullable) have false positives that need manual review."
+fi

--- a/skills/typo3-extension-upgrade/scripts/scan-deprecations.sh
+++ b/skills/typo3-extension-upgrade/scripts/scan-deprecations.sh
@@ -84,7 +84,8 @@ check_14() {
 }
 
 check_15() {
-    grep -rn "->execute()" "$target/Classes/"
+    # -e: pattern starts with "-", which grep would otherwise parse as an option
+    grep -rne "->execute()" "$target/Classes/"
 }
 
 check_16() {
@@ -139,7 +140,8 @@ check_28() {
     # Find TypoScript userFunc references
     grep -rn "userFunc\|preUserFunc\|postUserFunc" "$target/Configuration/TypoScript/"
     # Find PHP classes referenced in TypoScript
-    grep -rn "->render\|->process" "$target/Configuration/TypoScript/" | grep -v "#"
+    # -e: pattern starts with "-", which grep would otherwise parse as an option
+    grep -rne "->render\|->process" "$target/Configuration/TypoScript/" | grep -v "#"
 }
 
 check_29() {
@@ -147,7 +149,8 @@ check_29() {
 }
 
 check_30() {
-    grep -rn "->getName()\|Type::getName" "$target/Classes/"
+    # -e: pattern starts with "-", which grep would otherwise parse as an option
+    grep -rne "->getName()\|Type::getName" "$target/Classes/"
 }
 
 check_31() {
@@ -201,7 +204,8 @@ check_42() {
 }
 
 check_43() {
-    grep -rn "->select(\|Connection::select" "$target/Classes"
+    # -e: pattern starts with "-", which grep would otherwise parse as an option
+    grep -rne "->select(\|Connection::select" "$target/Classes"
 }
 
 check_44() {


### PR DESCRIPTION
Epic: https://github.com/netresearch/skill-repo-skill/issues/142
Part of: https://github.com/netresearch/typo3-conformance-skill/issues/82

## What changed

### 1. Cross-link to the canonical fact catalog

`references/api-changes.md`'s v12→v13 (§~436) and v13→v14 (§~491) sections restated v13/v14 breaking-change facts that typo3-conformance's `references/v14-deprecations.md` now owns canonically (see companion PR netresearch/typo3-conformance-skill#84). Per the fact-ownership rule in `skill-repo-skill` `skills/skill-repo/references/skill-quality.md`:

> Each fact and each trigger phrase has ONE canonical owning skill in the catalog; every other skill cross-references instead of restating.

Changes:
- Added a cross-link line at the top of the `## v12 → v13 Upgrade` and `## v13 → v14 Upgrade` sections pointing to the canonical catalog.
- Added inline canonical-fact citations to the `#[AsAllowedCallable]` (§1.9), `Icon::SIZE_*` (§1.2), and `getIndpEnv()` (§2.4 `#109551`) entries.
- Replaced the `### Additional v14 Changes` "Known Removals"/"Known Deprecations" recap (which restated both the canonical catalog and this same file's own detail sections above it) with a link-out.

### Kept as-is (execution-specific, this skill's ownership)

All search patterns, before/after fix code, version-compatibility notes, and the `GeneralUtility::getIndpEnv()` section's retro-born failure pattern (verified-false Gemini Code Assist claims, verification method, real PR reference) — none of that duplicates canonical, it's upgrade-execution content and a documented incident.

Items in `api-changes.md` with **no** canonical counterpart (`ExtensionConfiguration::getAll()`, `Type::getName()`, `f:uri.resource`, Scheduler interface signature, Bootstrap 5 CSS classes, TCA `renderType`, ARIA requirements, the whole v12→v13 Site Sets/Backend Module Registration/TCA Type Changes items) are untouched — they're not restated facts, they're unique execution content this skill owns.

### 2. `scripts/scan-deprecations.sh` (category-4 gap)

This skill had grep detection recipes in `api-changes.md`/`api-traps.md` but no runnable scanner. Added `scripts/scan-deprecations.sh <path>`, mechanically generated from every `**Search Pattern**` block in `api-changes.md` (v7→v8 through v13→v14, PHP 8.4, PSR-7, SC_OPTIONS — 43 checks) plus the 2 architectural-trap recipes in `api-traps.md` (`Connection::select()`, `callUserFunction()`). Each check reproduces the documented grep pattern verbatim, scoped to `<path>`. Documented in `SKILL.md`'s references table.

## Verification

Pattern fidelity — every generated check's grep pattern diffed character-for-character against its source doc line (only the path operand differs, by design):

```
Checked 43 entries from doc against 45 generated (api-changes.md only, traps excluded). Mismatches: 0
```

Script:

```
$ shellcheck skills/typo3-extension-upgrade/scripts/scan-deprecations.sh
(no output)
$ bash -n skills/typo3-extension-upgrade/scripts/scan-deprecations.sh
(no output)
```

Ran against a synthetic fixture containing `ExtensionConfiguration::getAll()`, `Icon::SIZE_SMALL`, `$GLOBALS['TSFE']->fe_user` — all three matched with correct labels; empty dir reports no matches; nonexistent path exits 1 with an error.

`scripts/audit-skills.sh` (skill-repo-skill origin/main):

```
SKILL: typo3-extension-upgrade
DESCRIPTION: 388 chars [PASS]
BODY: 440 words, 76 lines [PASS]
REFERENCES: 14 total -> 14/P1 reachable, 0 ORPHAN
SUMMARY: 1 skills, 0 FAIL, 0 WARN, 0 INFO, 0 ORPHAN refs
```

`SKILL.md` word count: 495/500 (trimmed 17 words elsewhere in the same file to make room for the new references-table row).

`skills/skill-repo/scripts/validate-skill.sh` (skill-repo-skill origin/main): 0 errors, 10 pre-existing README-template warnings unrelated to this change.

Part of https://github.com/netresearch/typo3-conformance-skill/issues/82 (not closed by this PR — conformance's PR closes it).
