### PR TITLE
chore(release): v3.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",


### PR DESCRIPTION
Version bump 3.10.0 → 3.10.1.

Changes since v3.10.0:

- chore: adopt the shared skill template
- chore(zizmor): drop the local policy copy, the reusable supplies it
- docs(skill): add composer why-not triage before per-dependency analysis
- docs(dual-compat): UP_TO sets are cumulative — floor-pin PHPUnit and Fractor too

Surfaces bumped: `.claude-plugin/plugin.json`, SKILL.md frontmatter version.
