### PR TITLE
chore(release): v3.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "typo3-extension-upgrade",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "author": {
     "name": "Netresearch DTT GmbH",


### PR DESCRIPTION
Release v3.11.0.

Version bump only.

Bumped: root `plugin.json`, `.claude-plugin/plugin.json`, every `skills/*/SKILL.md` frontmatter version. Parity verified with `check-version-parity.sh v3.11.0`.

Tag `v3.11.0` follows once this merges.