### PR TITLE
chore(release): v3.11.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "typo3-extension-upgrade",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/typo3-extension-upgrade/references/real-world-patterns.md
+++ b/skills/typo3-extension-upgrade/references/real-world-patterns.md
@@ -1,6 +1,6 @@
 # Real-World Upgrade Patterns
 
-> **Source**: netresearch/contexts extension upgrade from v11 to v12/v13 (2024-12)
+> **Source**: a production TYPO3 extension upgrade from v11 to v12/v13 (2024-12)
 
 ## Deprecation Patterns Discovered
 


### PR DESCRIPTION
Generalizes the source attribution in references/real-world-patterns.md. The repository it named is now an evaluation target of netresearch/agent-system-evals and skills must not name it — netresearch/agent-system-evals#3. No guidance changed. Patch bump on all version surfaces.