### PR TITLE
docs(typo3-extension-upgrade): document v14 AjaxRequest double-encoding trap

### DIFF
--- a/skills/typo3-extension-upgrade/references/api-traps.md
+++ b/skills/typo3-extension-upgrade/references/api-traps.md
@@ -180,6 +180,38 @@ done < /tmp/ext-classes.txt
 
 ---
 
+## v14 `AjaxRequest.withQueryArguments()` Dropped Its Decode-Neutralization Step — Undocumented, Version-Specific
+
+`@typo3/core/ajax/ajax-request.js`'s `withQueryArguments()` builds the query string differently per major version, and the difference is invisible from an extension's own unchanged JS.
+
+- **v12/v13**: routes the value through `InputTransformer.toSearchParams()`, which builds a `URLSearchParams`, serializes it, and then calls `decodeURI()` on the result. That `decodeURI()` step neutralizes exactly one prior layer of manual `encodeURIComponent()`/percent-encoding on the value (it leaves URI-reserved characters like `%3A`/`%2F` alone, but un-escapes a stray `%25` back to `%`). A caller that manually pre-encodes a value before passing it to `withQueryArguments()` still gets the correct, single-encoded value on the wire.
+- **v14**: `withQueryArguments()` was rewired to use the new `@typo3/core/factory/url-factory.js` module (`UrlFactory.createSearchParams()`) instead, appending the value onto the request URL's own `URLSearchParams` via `.append()` — with **no decode step at all**. The exact same manually-pre-encoded value now gets percent-encoded a second time (`%` → `%25`), producing a broken double-encoded value server-side (e.g. `1%3A%2Fcamino%2Ffile.pdf` → `1%253A%252Fcamino%252Ffile.pdf`).
+
+This is a real, reproducible behavior change (verified live: a v14 backend AJAX call using this pattern throws `InvalidFileException`/HTTP 500 when resolving the resulting identifier server-side; the identical code on v12/v13 resolves correctly), **not documented as a Breaking change** in TYPO3's official `Documentation/Changelog/14.0/` — the only related entry is `Feature-107104-IntroduceUrlFactoryJavaScriptModule.rst`, which describes `UrlFactory` as a new standalone utility and says nothing about `AjaxRequest`'s own internal implementation switching to it.
+
+**Symptom**: any extension JS that does `new AjaxRequest(url).withQueryArguments({ key: encodeURIComponent(someIdentifier) })` (a common pattern for passing a FAL combined identifier, `storage:/path`, which contains `:`/`/`) breaks silently on v14 with no visible in-page error unless the calling code explicitly renders an error state — the request still completes, the content container still refreshes, only the server-side resolution fails.
+
+**Search Pattern**:
+
+```bash
+grep -rn "encodeURIComponent" Resources/Public/JavaScript/
+# For each hit, check whether it feeds a .withQueryArguments()/.get() call, not a .post()/.put() body
+```
+
+**Fix** — do not pre-encode; let `withQueryArguments()` do it once (this is the shape that works correctly on v12, v13, AND v14):
+
+```js
+// ❌ Correct-looking on v12/v13, silently broken on v14
+new AjaxRequest(actionUrl).withQueryArguments({ target: encodeURIComponent(identifier) }).get();
+
+// ✅ Works on all three
+new AjaxRequest(actionUrl).withQueryArguments({ target: identifier }).get();
+```
+
+**Verification caveat**: do not assume a version-spanning "pre-existing bug" claim from extension-code similarity alone. The extension's own JS file can be byte-identical across v12/v13/v14 checkouts while TYPO3 core's own `ajax-request.js`/`input-transformer.js`/`url-factory.js` differ per version — read the actual vendored core JS for **each** version under test (`vendor/typo3/cms-core/Resources/Public/JavaScript/ajax/*.js`) rather than diffing only the extension's own file, and reproduce the exact call path in Node (or a real browser) per version before generalizing a fix across a v12/v13/v14 maintenance-branch set. See `verification.md`.
+
+---
+
 ## See Also
 
 - `upgrade-v11-to-v12.md` — v12 FormEngine DI nodes (`setData()` workaround for [#100670](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100670-DIAwareFormEngineNodes.html))

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -273,6 +273,10 @@ parameters:
 
 `phpstan/extension-installer` auto-loads any installed PHPStan extensions — once you remove `saschaegerer/phpstan-typo3` from the v12/v14 dev branches' `composer.json`, no manual `includes:` cleanup is needed.
 
+### `AjaxRequest.withQueryArguments()` double-encodes on v14 — undocumented, JS-only
+
+v14 rewired `withQueryArguments()` to use the new `UrlFactory.createSearchParams()` instead of v12/v13's `InputTransformer.toSearchParams()`, silently dropping a `decodeURI()` step that used to neutralize one layer of manual pre-encoding. Any extension JS calling `.withQueryArguments({ key: encodeURIComponent(value) })` — a common pattern for a FAL combined identifier (`storage:/path`) — breaks on v14 (double-encoded value, server-side resolution fails) while the identical code stays correct on v12/v13. Not listed in `Documentation/Changelog/14.0/` as a Breaking change. Full writeup with the fix and verification method: `api-traps.md`.
+
 ---
 
 ## Dual-version compatibility guards


### PR DESCRIPTION
## Summary
- TYPO3 v14 rewired `AjaxRequest.withQueryArguments()` to route through the new `UrlFactory.createSearchParams()` instead of v12/v13's `InputTransformer.toSearchParams()`, silently dropping a `decodeURI()` step that used to neutralize one layer of manual pre-encoding.
- Any extension JS calling `withQueryArguments({ key: encodeURIComponent(value) })` (a common pattern for FAL combined identifiers) breaks on v14 with a double-encoded value server-side, while the identical code stays correct on v12/v13.
- Not documented as a Breaking change in `Documentation/Changelog/14.0/` — the only related entry (`Feature-107104-IntroduceUrlFactoryJavaScriptModule.rst`) describes `UrlFactory` as a new standalone utility, not that `AjaxRequest` itself was rewired to use it.
- Adds a full writeup with search pattern and fix to `api-traps.md`, plus a short cross-reference in `upgrade-v13-to-v14.md`'s "Expanded gotchas" section.

## Why this matters for the skill
Discovered while porting a real extension (meine-krankenkasse/typo3-search-algolia) from v13 to v14: initially over-generalized a v14-only fix onto v12/v13 maintenance branches based on the extension's own JS file being byte-identical across versions, without checking that TYPO3 core's own vendored `ajax-request.js`/`input-transformer.js` differ per major version. Verified live against a real v14 instance (HTTP 500 → correct resolution) and independently reproduced the exact call path for v12, v13, and v14 in Node before writing this up, to avoid documenting an unverified claim.

## Test plan
- [x] `markdownlint-cli2` clean against the repo's own `.markdownlint-cli2.jsonc` (3 remaining hits are pre-existing, unrelated to this change)
- [x] Content verified against real TYPO3 v12/v13/v14 vendored core JS and a live v14 backend reproduction