### PR TITLE
chore(release): v3.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "repository": "https://github.com/netresearch/typo3-extension-upgrade-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "typo3-extension-upgrade",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "author": {
     "name": "Netresearch DTT GmbH",


### PR DESCRIPTION
## Summary
- Version bump 3.11.1 -> 3.12.0 (minor: new reference-doc capability, no behavior change)
- Follows the established release flow: bump `.claude-plugin/plugin.json` and `plugin.json`, PR to main, then a signed annotated tag on the merge commit

## Included since v3.11.1
- #53 v14 `AjaxRequest.withQueryArguments()` double-encoding trap (api-traps.md + upgrade-v13-to-v14.md cross-reference)
- #52 v13 backend CSS reusing generic extension class names