### PR TITLE
fix(searches): look in Tests/ too, where a removed class kills the whole suite

### DIFF
--- a/evals/eval_queries.json
+++ b/evals/eval_queries.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "typo3-extension-upgrade",
+  "note": "Trigger evals in the format agentskills.io documents: realistic requests, labelled with whether this skill should be consulted. They test ROUTING, which the assertion evals in evals.json cannot: those are graded by matching the answer text, so they only ever measure what the skill does once it is already loaded. Prompts are written in the words a maintainer or a colleague would use, not in the skill's own, and never copied from a benchmark that measures this skill. The negatives matter as much as the positives here: this skill and typo3-conformance both answer to 'TYPO3' and 'extension', and a request that names neither an upgrade nor a target version has been observed going to whichever of them the model reached for first.",
+  "queries": [
+    {
+      "query": "Our extension should run on whichever TYPO3 LTS is current now — please sort that out.",
+      "should_trigger": true,
+      "note": "names no version, no tool and not the word upgrade — the shape that lost to a sibling skill until the description opened with it"
+    },
+    {
+      "query": "Does this still run on v14, and if not, what has to change?",
+      "should_trigger": true
+    },
+    {
+      "query": "We are still on 12.4 and want to go to 13.4. What breaks?",
+      "should_trigger": true
+    },
+    {
+      "query": "After the version bump the tests do not even start any more.",
+      "should_trigger": true,
+      "note": "a removed class referenced from Tests/ stops PHPUnit while loading the suite"
+    },
+    {
+      "query": "This has to keep working on the old LTS while we get it ready for the new one.",
+      "should_trigger": true
+    },
+    {
+      "query": "The extension scanner reports a couple of dozen deprecations. Where do I start?",
+      "should_trigger": true
+    },
+    {
+      "query": "Which TYPO3 versions does this extension say it supports? composer.json and ext_emconf.php disagree.",
+      "should_trigger": false,
+      "note": "typo3-conformance owns what an extension declares; nothing here is being upgraded"
+    },
+    {
+      "query": "Give this extension a once-over before I hand it on — what stands out?",
+      "should_trigger": false,
+      "note": "an open review, not a target version — typo3-conformance"
+    },
+    {
+      "query": "Saving a record in one of our backend modules silently keeps the previous value. Find out why.",
+      "should_trigger": false,
+      "note": "a runtime defect, unrelated to any version"
+    }
+  ]
+}

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typo3-extension-upgrade
-description: "Use when upgrading TYPO3 extensions to newer LTS versions (v11->v12, v12->v13, v13->v14 - v14.3 LTS is the current target), running Extension Scanner, Rector, Fractor, PHPStan, fixing deprecated APIs, or resolving compatibility issues. Also triggers on: migration, version upgrade, deprecated API, dual-version compatibility, Fluid 5 strict VHs, HashService removal, ext_tables.php split."
+description: "Use when an extension has to work with a newer or the current TYPO3 LTS, when a version bump breaks compatibility or leaves deprecated APIs behind, when upgrading v11->v12, v12->v13 or v13->v14 (v14.3 LTS is the current target), when one codebase must stay compatible with two versions, when running Extension Scanner, Rector, Fractor or PHPStan against a target version, or when a specific v14 breaker bites - Fluid 5 strict ViewHelpers, HashService removal, the ext_tables.php split."
 ---
 
 # TYPO3 Extension Upgrade Skill

--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -227,9 +227,9 @@ grep -rn "'wizards'\s*=>\|'wizard_'" Configuration/TCA/
 
 ## v11 → v12 Upgrade
 
-### Doctrine DBAL 4.x (Critical)
+### Doctrine DBAL: PDO constants removed
 
-#### PDO Constants Removed
+TYPO3 v12 ships DBAL 3. The DBAL 4 changes that used to sit here moved to v12 → v13, where they belong.
 
 #### Search Pattern
 ```bash
@@ -249,52 +249,6 @@ grep -rn "PDO::PARAM_" Classes/ Tests/
 ```php
 use TYPO3\CMS\Core\Database\Connection;
 ```
-
-#### QueryBuilder execute() Removed
-
-#### Search Pattern
-```bash
-grep -rn "->execute()" Classes/ Tests/
-```
-
-#### Replace
-
-| Before (DBAL 3.x) | After (DBAL 4.x) |
-|-------------------|------------------|
-| `$queryBuilder->execute()` (SELECT) | `$queryBuilder->executeQuery()` |
-| `$queryBuilder->execute()` (INSERT/UPDATE/DELETE) | `$queryBuilder->executeStatement()` |
-
-#### Example Migration
-```php
-// Before (DBAL 3.x)
-$result = $queryBuilder
-    ->select('*')
-    ->from('pages')
-    ->execute();
-
-// After (DBAL 4.x)
-$result = $queryBuilder
-    ->select('*')
-    ->from('pages')
-    ->executeQuery();
-```
-
-#### ParameterType Enum (PHPStan Warning)
-
-In Doctrine DBAL 4.x, type parameters changed from `int` to `ParameterType` enum:
-
-```php
-// This works but PHPStan may complain:
-->createNamedParameter($value, Connection::PARAM_INT)
-
-// PHPStan ignore pattern for dual v12/v13 compatibility:
-# Build/phpstan.neon
-parameters:
-    ignoreErrors:
-        - '~Parameter \\#2 \\$type of method .* expects .*, int given~'
-```
-
-**Note**: TYPO3 Core provides `Connection::PARAM_*` constants that work across versions, but PHPStan may still report type mismatches during the transition period
 
 ### GeneralUtility Deprecated Methods
 
@@ -437,6 +391,54 @@ grep -rn "BackendUtility::wrapClickMenuOnIcon\|getClickMenuOnIconTagParameters" 
 
 The `$TSFE` properties deprecated below are fully removed in v14.0 — see typo3-conformance's canonical [`v14-deprecations.md`](https://github.com/netresearch/typo3-conformance-skill/blob/main/skills/typo3-conformance/references/v14-deprecations.md) §1.3 (`TypoScriptFrontendController` removal, #107831) for the removal fact. This section keeps the v13 migration execution: search patterns and fix code.
 
+### Doctrine DBAL 4: QueryBuilder execute() removed
+
+Deprecated in v12, removed in v13 together with the DBAL 4 upgrade. It sat under v11 → v12 in earlier revisions of this file, which is one major too early.
+
+#### Search Pattern
+```bash
+grep -rne "->execute()" Classes/ Tests/
+```
+
+#### Replace
+
+| Before (DBAL 3.x) | After (DBAL 4.x) |
+|-------------------|------------------|
+| `$queryBuilder->execute()` (SELECT) | `$queryBuilder->executeQuery()` |
+| `$queryBuilder->execute()` (INSERT/UPDATE/DELETE) | `$queryBuilder->executeStatement()` |
+
+#### Example Migration
+```php
+// Before (DBAL 3.x)
+$result = $queryBuilder
+    ->select('*')
+    ->from('pages')
+    ->execute();
+
+// After (DBAL 4.x)
+$result = $queryBuilder
+    ->select('*')
+    ->from('pages')
+    ->executeQuery();
+```
+
+#### ParameterType Enum (PHPStan Warning)
+
+In Doctrine DBAL 4.x, type parameters changed from `int` to `ParameterType` enum:
+
+```php
+// This works but PHPStan may complain:
+->createNamedParameter($value, Connection::PARAM_INT)
+
+// PHPStan ignore pattern for dual v12/v13 compatibility:
+# Build/phpstan.neon
+parameters:
+    ignoreErrors:
+        - '~Parameter \\#2 \\$type of method .* expects .*, int given~'
+```
+
+**Note**: TYPO3 Core provides `Connection::PARAM_*` constants that work across versions, but PHPStan may still report type mismatches during the transition period
+
 ### Request Attributes (Critical)
 
 #### Search Pattern
@@ -505,7 +507,7 @@ TYPO3 v14 requires explicit opt-in for methods callable through TypoScript/TScon
 # Find TypoScript userFunc references
 grep -rn "userFunc\|preUserFunc\|postUserFunc" Configuration/TypoScript/
 # Find PHP classes referenced in TypoScript
-grep -rn "->render\|->process" Configuration/TypoScript/ | grep -v "#"
+grep -rne "->render\|->process" Configuration/TypoScript/ | grep -v "#"
 ```
 
 #### Affected
@@ -555,7 +557,7 @@ $extConfig = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['my_extension'] ?? [];
 
 #### Search Pattern
 ```bash
-grep -rn "->getName()\|Type::getName" Classes/ Tests/
+grep -rne "->getName()\|Type::getName" Classes/ Tests/
 ```
 
 #### Replace
@@ -580,7 +582,7 @@ if ($type instanceof StringType || $type instanceof TextType) { }
 
 #### Search Pattern
 ```bash
-grep -rn "Icon::SIZE_SMALL\|Icon::SIZE_DEFAULT\|Icon::SIZE_MEDIUM\|Icon::SIZE_LARGE" Classes/ Tests/
+grep -rnE "Icon::SIZE_(SMALL|DEFAULT|MEDIUM|LARGE|MEGA|OVERLAY)" Classes/ Tests/
 ```
 
 #### Replace
@@ -828,7 +830,10 @@ PHP 8.4 deprecates implicit nullable parameters. This affects all TYPO3 versions
 
 #### Search Pattern
 ```bash
-# Find parameters with null default but no explicit nullable type
+# Find parameters with null default but no explicit nullable type.
+# One line at a time, so a signature broken across lines slips through: this is
+# a first pass, not the verdict. The authoritative check is a parser --
+# `rector process --dry-run` with the PHP 8.4 set, or PHPStan at level 6+.
 grep -rn '\(.*\$[a-zA-Z_]* = null\)' Classes/ Tests/ | grep -v '?[a-zA-Z_\\]*\s*\$'
 ```
 
@@ -1032,7 +1037,8 @@ grep -rn "\$TSFE->fe_user\|\$TSFE->page\|\$TSFE->rootLine" Classes/ Tests/
 # v13→v14.3: getIndpEnv() deprecation (use NormalizedParams)
 grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Tests/ Configuration/
 
-# PHP 8.4: Implicit nullable parameters
+# PHP 8.4: Implicit nullable parameters (line-based; a signature broken across
+# lines slips through -- confirm with `rector process --dry-run`)
 grep -rn '\$[a-zA-Z_]* = null)' Classes/ Tests/ | grep -v '?'
 
 # PHP 8.4: Old TCA items format
@@ -1074,9 +1080,11 @@ After making changes:
 
 When upgrading extensions, tests often need adjustments to work with new TYPO3 versions.
 
-### Functional Test Container Isolation
+### Unit Test Container Isolation
 
-In TYPO3 v12+, singleton services may persist state between tests. Reset the Container before each test:
+In TYPO3 v12+, singleton services may persist state between tests. Reset the container before each test.
+
+**`UnitTestCase` only.** `FunctionalTestCase` resets instance state through its own lifecycle — it calls `GeneralUtility::purgeInstances()` for you — and a hand-rolled reset in a functional test fights that rather than helping it. On `UnitTestCase`, prefer the property the testing framework provides, `protected bool $resetSingletonInstances = true;`, over calling the reset yourself.
 
 #### Problem Pattern
 ```php
@@ -1093,10 +1101,12 @@ protected function setUp(): void
 {
     parent::setUp();
 
-    // Reset Container to ensure clean state
+    // Drop every singleton instance the previous test left behind.
     GeneralUtility::resetSingletonInstances([]);
 
-    // Flush all caches for complete reset
+    // Only if the test under it resolves backend routes. This initialises the
+    // backend router; it does not flush caches, whatever an older version of
+    // this recipe claimed.
     Bootstrap::initializeBackendRouter();
 }
 ```

--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -1095,7 +1095,6 @@ In TYPO3 v12+, singleton services may persist state between tests. Reset the con
 #### Fix Pattern
 ```php
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Core\Bootstrap;
 
 protected function setUp(): void
 {
@@ -1103,13 +1102,16 @@ protected function setUp(): void
 
     // Drop every singleton instance the previous test left behind.
     GeneralUtility::resetSingletonInstances([]);
-
-    // Only if the test under it resolves backend routes. This initialises the
-    // backend router; it does not flush caches, whatever an older version of
-    // this recipe claimed.
-    Bootstrap::initializeBackendRouter();
 }
 ```
+
+Earlier revisions of this recipe followed the reset with
+`Bootstrap::initializeBackendRouter()` and a comment claiming it flushed all
+caches. It flushes nothing, and since v11.5 it does not exist: the method is
+present in `TYPO3\CMS\Core\Core\Bootstrap` in v9.5 and v10.4 and gone from
+v11.5, v12.4, v13.4 and v14.3 — checked against the core source for each. Copied
+into a v12+ test it is a fatal undefined-method call in `setUp()`, which fails
+every test in the class.
 
 ### Session State in Test Fixtures
 

--- a/skills/typo3-extension-upgrade/references/api-changes.md
+++ b/skills/typo3-extension-upgrade/references/api-changes.md
@@ -8,12 +8,12 @@ Search patterns, replacements, and key breaking changes organized by TYPO3 versi
 
 ### Database Layer: TYPO3_DB → Doctrine DBAL
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "\$GLOBALS\['TYPO3_DB'\]\|exec_SELECTquery\|exec_INSERTquery\|exec_UPDATEquery\|exec_DELETEquery" Classes/
+grep -rn "\$GLOBALS\['TYPO3_DB'\]\|exec_SELECTquery\|exec_INSERTquery\|exec_UPDATEquery\|exec_DELETEquery" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before (v7) | After (v8+) |
 |-------------|-------------|
@@ -23,7 +23,7 @@ grep -rn "\$GLOBALS\['TYPO3_DB'\]\|exec_SELECTquery\|exec_INSERTquery\|exec_UPDA
 | `$GLOBALS['TYPO3_DB']->exec_DELETEquery()` | `$queryBuilder->delete()` |
 | `$GLOBALS['TYPO3_DB']->fullQuoteStr()` | `$queryBuilder->createNamedParameter()` |
 
-**Example Migration**
+#### Example Migration
 ```php
 // Before (v7)
 $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_content', 'pid=' . $pid);
@@ -40,7 +40,7 @@ $rows = $queryBuilder
 
 ### ExtJS/Prototype Removal
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "Ext\.onReady\|new Ext\.\|Prototype\.\|Element\.extend" Resources/
 ```
@@ -49,12 +49,12 @@ grep -rn "Ext\.onReady\|new Ext\.\|Prototype\.\|Element\.extend" Resources/
 
 ### Icon Factory
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "IconUtility::\|t3skin\|t3lib_iconWorks" Classes/
+grep -rn "IconUtility::\|t3skin\|t3lib_iconWorks" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before | After |
 |--------|-------|
@@ -67,7 +67,7 @@ grep -rn "IconUtility::\|t3skin\|t3lib_iconWorks" Classes/
 
 ### Site Configuration Introduction
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "sys_domain\|config\.baseURL\|absRefPrefix\s*=\s*auto" Configuration/
 ```
@@ -76,12 +76,12 @@ grep -rn "sys_domain\|config\.baseURL\|absRefPrefix\s*=\s*auto" Configuration/
 
 ### PSR-15 Middleware
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "AbstractUserAuthentication\|tslib_fe\|tslib_cObj" Classes/
+grep -rn "AbstractUserAuthentication\|tslib_fe\|tslib_cObj" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before | After |
 |--------|-------|
@@ -91,7 +91,7 @@ grep -rn "AbstractUserAuthentication\|tslib_fe\|tslib_cObj" Classes/
 
 ### Routing API
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "tx_realurl\|cooluri\|simulatestatic" Configuration/
 ```
@@ -100,9 +100,9 @@ grep -rn "tx_realurl\|cooluri\|simulatestatic" Configuration/
 
 ### Signal/Slot Deprecation Start
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "SignalSlotDispatcher\|->connect\(" Classes/
+grep -rn "SignalSlotDispatcher\|->connect\(" Classes/ Tests/
 ```
 
 **Note**: Mark for migration to PSR-14 Events (complete in v10).
@@ -113,7 +113,7 @@ grep -rn "SignalSlotDispatcher\|->connect\(" Classes/
 
 ### Symfony 5 Upgrade
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "Symfony\\\\Component\\\\Console\\\\Command\|setDescription\|setHelp" Classes/Command/
 ```
@@ -122,9 +122,9 @@ grep -rn "Symfony\\\\Component\\\\Console\\\\Command\|setDescription\|setHelp" C
 
 ### Dependency Injection
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "GeneralUtility::makeInstance\|ObjectManager::get" Classes/
+grep -rn "GeneralUtility::makeInstance\|ObjectManager::get" Classes/ Tests/
 ```
 
 **Replace**: Use constructor injection with `Services.yaml`.
@@ -141,12 +141,12 @@ services:
 
 ### PSR-14 Events
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "SignalSlotDispatcher\|->emit\|->connect\(" Classes/
+grep -rn "SignalSlotDispatcher\|->emit\|->connect\(" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before | After |
 |--------|-------|
@@ -155,7 +155,7 @@ grep -rn "SignalSlotDispatcher\|->emit\|->connect\(" Classes/
 
 ### Fluid Namespace
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "{namespace\|xmlns:f=" Resources/Private/
 ```
@@ -177,12 +177,12 @@ grep -rn "{namespace\|xmlns:f=" Resources/Private/
 
 ### Fluid Standalone
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "TYPO3Fluid\|StandaloneView\|setTemplatePathAndFilename" Classes/
+grep -rn "TYPO3Fluid\|StandaloneView\|setTemplatePathAndFilename" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 ```php
 // Before
 $view->setTemplatePathAndFilename($templatePath);
@@ -194,7 +194,7 @@ $view->setTemplateRootPaths([$rootPath]);
 
 ### Backend Controller Changes
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "extends ActionController\|AbstractModule" Classes/Controller/
 ```
@@ -216,7 +216,7 @@ public function indexAction(): ResponseInterface {
 
 ### TCA Wizard Changes
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "'wizards'\s*=>\|'wizard_'" Configuration/TCA/
 ```
@@ -231,12 +231,12 @@ grep -rn "'wizards'\s*=>\|'wizard_'" Configuration/TCA/
 
 #### PDO Constants Removed
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "PDO::PARAM_" Classes/
+grep -rn "PDO::PARAM_" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before | After |
 |--------|-------|
@@ -245,26 +245,26 @@ grep -rn "PDO::PARAM_" Classes/
 | `PDO::PARAM_BOOL` | `Connection::PARAM_BOOL` |
 | `PDO::PARAM_NULL` | `Connection::PARAM_NULL` |
 
-**Required Import**
+#### Required Import
 ```php
 use TYPO3\CMS\Core\Database\Connection;
 ```
 
 #### QueryBuilder execute() Removed
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "->execute()" Classes/
+grep -rn "->execute()" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before (DBAL 3.x) | After (DBAL 4.x) |
 |-------------------|------------------|
 | `$queryBuilder->execute()` (SELECT) | `$queryBuilder->executeQuery()` |
 | `$queryBuilder->execute()` (INSERT/UPDATE/DELETE) | `$queryBuilder->executeStatement()` |
 
-**Example Migration**
+#### Example Migration
 ```php
 // Before (DBAL 3.x)
 $result = $queryBuilder
@@ -298,12 +298,12 @@ parameters:
 
 ### GeneralUtility Deprecated Methods
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "GeneralUtility::_GET\|GeneralUtility::_POST\|GeneralUtility::_GP" Classes/
+grep -rn "GeneralUtility::_GET\|GeneralUtility::_POST\|GeneralUtility::_GP" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before | After |
 |--------|-------|
@@ -311,7 +311,7 @@ grep -rn "GeneralUtility::_GET\|GeneralUtility::_POST\|GeneralUtility::_GP" Clas
 | `GeneralUtility::_POST('param')` | `$_POST['param'] ?? null` |
 | `GeneralUtility::_GP('param')` | `$_GET['param'] ?? $_POST['param'] ?? null` |
 
-**For Controllers/Middleware (PSR-7)**
+#### For Controllers/Middleware (PSR-7)
 ```php
 // GET parameters
 $value = $request->getQueryParams()['param'] ?? null;
@@ -322,12 +322,12 @@ $value = $request->getParsedBody()['param'] ?? null;
 
 ### TCA Required Field
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "'eval'.*'required'" Configuration/TCA/
 ```
 
-**Replace**
+#### Replace
 ```php
 // Before
 'config' => [
@@ -345,12 +345,12 @@ grep -rn "'eval'.*'required'" Configuration/TCA/
 
 ### TCA inputLink → type=link
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "'renderType' => 'inputLink'" Configuration/TCA/
 ```
 
-**Replace**
+#### Replace
 ```php
 // Before (deprecated in v12)
 'config' => [
@@ -369,12 +369,12 @@ grep -rn "'renderType' => 'inputLink'" Configuration/TCA/
 
 ### Form Element Data Structure
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "itemFormElID" Classes/
+grep -rn "itemFormElID" Classes/ Tests/
 ```
 
-**Fix Pattern**
+#### Fix Pattern
 ```php
 // Before (removed in v12)
 $id = $this->data['parameterArray']['itemFormElID'];
@@ -386,12 +386,12 @@ $baseId = trim($baseId, '_');
 
 ### xml2array Null Handling
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "xml2array" Classes/
+grep -rn "xml2array" Classes/ Tests/
 ```
 
-**Fix Pattern**
+#### Fix Pattern
 ```php
 // Before
 if ($row['field'] !== '') {
@@ -406,7 +406,7 @@ if (!empty($row['field'])) {
 
 ### FlexForm Structure (Fractor handles)
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "<required>1</required>" Configuration/FlexForms/
 ```
@@ -415,7 +415,7 @@ grep -rn "<required>1</required>" Configuration/FlexForms/
 
 ### TypoScript Conditions
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "\[end\]" Configuration/TypoScript/
 ```
@@ -424,9 +424,9 @@ grep -rn "\[end\]" Configuration/TypoScript/
 
 ### Click Menu Parameters
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "BackendUtility::wrapClickMenuOnIcon\|getClickMenuOnIconTagParameters" Classes/
+grep -rn "BackendUtility::wrapClickMenuOnIcon\|getClickMenuOnIconTagParameters" Classes/ Tests/
 ```
 
 **Fix**: Remove 4th parameter if `'true'` or `'1'`.
@@ -439,12 +439,12 @@ The `$TSFE` properties deprecated below are fully removed in v14.0 — see typo3
 
 ### Request Attributes (Critical)
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "\$TSFE->fe_user\|\$GLOBALS\['TSFE'\]->fe_user" Classes/
+grep -rn "\$TSFE->fe_user\|\$GLOBALS\['TSFE'\]->fe_user" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before (v12) | After (v13) |
 |--------------|-------------|
@@ -455,7 +455,7 @@ grep -rn "\$TSFE->fe_user\|\$GLOBALS\['TSFE'\]->fe_user" Classes/
 
 ### Site Sets Introduction
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "ext_typoscript_setup\.typoscript\|ext_typoscript_constants"
 ```
@@ -472,7 +472,7 @@ dependencies:
 
 ### Backend Module Registration
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "registerModule\|TYPO3_MOD_PATH" ext_tables.php
 ```
@@ -481,7 +481,7 @@ grep -rn "registerModule\|TYPO3_MOD_PATH" ext_tables.php
 
 ### TCA Type Changes
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "'type'\s*=>\s*'text'" Configuration/TCA/
 ```
@@ -500,7 +500,7 @@ For the full v14 removal and deprecation fact catalog, see typo3-conformance's c
 
 TYPO3 v14 requires explicit opt-in for methods callable through TypoScript/TSconfig. Without the attribute, calls fail with `AllowedCallableException`.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 # Find TypoScript userFunc references
 grep -rn "userFunc\|preUserFunc\|postUserFunc" Configuration/TypoScript/
@@ -508,7 +508,7 @@ grep -rn "userFunc\|preUserFunc\|postUserFunc" Configuration/TypoScript/
 grep -rn "->render\|->process" Configuration/TypoScript/ | grep -v "#"
 ```
 
-**Affected**
+#### Affected
 - `userFunc` in USER/USER_INT content objects
 - `preUserFunc`, `postUserFunc`, `preUserFuncInt`, `postUserFuncInt` in stdWrap
 - TSconfig `renderFunc` in suggest wizard
@@ -534,12 +534,12 @@ class MyProcessor
 
 ### ExtensionConfiguration::getAll() Removed (Critical)
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "ExtensionConfiguration::getAll\|->getAll()" Classes/
+grep -rn "ExtensionConfiguration::getAll\|->getAll()" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 ```php
 // Before (removed in v14)
 $allConfig = GeneralUtility::makeInstance(ExtensionConfiguration::class)->getAll();
@@ -553,12 +553,12 @@ $extConfig = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['my_extension'] ?? [];
 
 ### Doctrine DBAL 4.x Type::getName() Removed
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "->getName()\|Type::getName" Classes/
+grep -rn "->getName()\|Type::getName" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 ```php
 // Before (DBAL 3.x)
 use Doctrine\DBAL\Types\Type;
@@ -578,12 +578,12 @@ if ($type instanceof StringType || $type instanceof TextType) { }
 
 **Removed in v14.0** (canonical fact: v14-deprecations.md §1.2).
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "Icon::SIZE_SMALL\|Icon::SIZE_DEFAULT\|Icon::SIZE_MEDIUM\|Icon::SIZE_LARGE" Classes/
+grep -rn "Icon::SIZE_SMALL\|Icon::SIZE_DEFAULT\|Icon::SIZE_MEDIUM\|Icon::SIZE_LARGE" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 ```php
 // Before (deprecated)
 use TYPO3\CMS\Core\Imaging\Icon;
@@ -605,12 +605,12 @@ $icon = $iconFactory->getIcon('actions-edit', IconSize::SMALL);
 
 ### f:uri.resource Not Available in Non-Extbase Modules
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "f:uri.resource\|<f:uri.resource" Resources/Private/
 ```
 
-**Replace**
+#### Replace
 ```html
 <!-- Before (fails in non-Extbase backend modules) -->
 <link rel="stylesheet" href="{f:uri.resource(path:'Css/backend.css')}" />
@@ -623,7 +623,7 @@ grep -rn "f:uri.resource\|<f:uri.resource" Resources/Private/
 
 ### Scheduler Interface Signature Changes
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "AdditionalFieldProviderInterface\|getAdditionalFields" Classes/Task/
 ```
@@ -649,12 +649,12 @@ public function getAdditionalFields(
 
 TYPO3 v14 uses Bootstrap 5. Update CSS classes in templates.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "btn-default\|badge-primary\|badge-success\|badge-danger\|badge-warning\|badge-info" Resources/
 ```
 
-**Replace**
+#### Replace
 
 | Before (Bootstrap 4) | After (Bootstrap 5) |
 |---------------------|---------------------|
@@ -669,12 +669,12 @@ grep -rn "btn-default\|badge-primary\|badge-success\|badge-danger\|badge-warning
 
 When checking for custom TCA field types, use `renderType`, not `type`.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "\['config'\]\['type'\]" Classes/Hook/
 ```
 
-**Fix**
+#### Fix
 ```php
 // ❌ Wrong - checks base type (input, text, etc.)
 $renderType = $fieldConfig['config']['type'] ?? '';
@@ -687,12 +687,12 @@ $renderType = $fieldConfig['config']['renderType'] ?? '';
 
 TYPO3 v14 enforces stricter WCAG 2.1 AA compliance. Add ARIA attributes to templates.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "role=\"main\"\|aria-label\|aria-describedby" Resources/Private/
 ```
 
-**Required Additions**
+#### Required Additions
 ```html
 <!-- Main content wrapper -->
 <div class="module" role="main" aria-label="My Module">
@@ -736,7 +736,6 @@ $icon = $iconFactory->getIcon('actions-edit', 'small');
 ### GeneralUtility::getIndpEnv() Deprecated -- Use NormalizedParams (v14.3)
 
 > **Canonical fact entry**: v14-deprecations.md §2.4 `#109551`.
-
 > **Deprecated: v14.3, scheduled for removal in v15.0**
 > **Source**: `typo3/cms-core` v14.3.0 vendor source, `Classes/Utility/GeneralUtility.php` (the `@deprecated` tag is on the method itself).
 > **Verify locally**: `grep -n -B5 "function getIndpEnv(" vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php` -- shows the docblock with `@deprecated since TYPO3 v14.3, will be removed in TYPO3 v15.0` directly above the method signature (line ~2142 in v14.3.0).
@@ -745,9 +744,9 @@ $icon = $iconFactory->getIcon('actions-edit', 'small');
 
 > ⚠️ Don't trust AI assistants on this deprecation timing. Gemini Code Assist has been observed claiming `getIndpEnv()` was deprecated in v13.0 / removed in v14.0, and that `NormalizedParams::createFromServerParams()` was removed in v14.0 in favour of a (non-existent) `NormalizedParamsFactory` class. All three claims are wrong -- verified false against `typo3/cms-core` v14.3.0 vendor source. Always verify deprecation timing by reading the `@deprecated` annotation in `vendor/typo3/cms-core/`.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/
+grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Tests/ Configuration/
 ```
 
 **Method mapping** (`getIndpEnv($name)` → `NormalizedParams` method)
@@ -765,7 +764,7 @@ grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/
 | `'TYPO3_SITE_URL'` | `getSiteUrl()` |
 | `'TYPO3_SITE_PATH'` | `getSitePath()` |
 
-**Replace -- in controllers/middleware (request injected)**
+#### Replace -- in controllers/middleware (request injected)
 ```php
 // ❌ Before
 $ip = GeneralUtility::getIndpEnv('REMOTE_ADDR');
@@ -774,7 +773,7 @@ $ip = GeneralUtility::getIndpEnv('REMOTE_ADDR');
 $ip = $request->getAttribute('normalizedParams')?->getRemoteAddress() ?? '';
 ```
 
-**Replace -- in services/auth services (no request injected)**
+#### Replace -- in services/auth services (no request injected)
 
 For services where `ServerRequestInterface` cannot be injected (e.g. `AbstractAuthenticationService` subclasses, CLI commands), fall back through `$GLOBALS['TYPO3_REQUEST']` and finally re-create `NormalizedParams` from `$_SERVER`:
 
@@ -805,7 +804,7 @@ private function getRemoteAddress(): string
 }
 ```
 
-**Dual-version compatibility (v12.4 + v13.4 + v14.3)**
+#### Dual-version compatibility (v12.4 + v13.4 + v14.3)
 
 The migration is safe across the entire supported range with **no compatibility shims**: `NormalizedParams` has been part of TYPO3 since v9.4, and `normalizedParams` has been a request attribute since v10. Just migrate to `NormalizedParams` in one step -- it works on v12.4 / v13.4 / v14.3 unchanged, and silences the v14.3 deprecation.
 
@@ -827,13 +826,13 @@ These changes are required for PHP 8.4 compatibility regardless of TYPO3 version
 
 PHP 8.4 deprecates implicit nullable parameters. This affects all TYPO3 versions.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 # Find parameters with null default but no explicit nullable type
-grep -rn '\(.*\$[a-zA-Z_]* = null\)' Classes/ | grep -v '?[a-zA-Z_\\]*\s*\$'
+grep -rn '\(.*\$[a-zA-Z_]* = null\)' Classes/ Tests/ | grep -v '?[a-zA-Z_\\]*\s*\$'
 ```
 
-**Replace**
+#### Replace
 ```php
 // ❌ Deprecated in PHP 8.4 (E_DEPRECATED), Error in PHP 9.0
 public function foo(string $param = null): void
@@ -844,7 +843,7 @@ public function foo(?string $param = null): void
 public function bar(?array $config = null): void
 ```
 
-**Common Occurrences**
+#### Common Occurrences
 - FlexForm configuration parameters
 - Optional service dependencies in constructors
 - Default TCA configuration arrays
@@ -854,12 +853,12 @@ public function bar(?array $config = null): void
 
 ### TCA Items Array Format
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "'items'\s*=>\s*\[" Configuration/TCA/ | grep -v "label"
 ```
 
-**Replace**
+#### Replace
 ```php
 // ❌ Old format (deprecated)
 'items' => [
@@ -882,12 +881,12 @@ grep -rn "'items'\s*=>\s*\[" Configuration/TCA/ | grep -v "label"
 
 When migrating context matching or middleware that needs request data:
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "\$_GET\['\|\$_POST\['" Classes/
+grep -rn "\$_GET\['\|\$_POST\['" Classes/ Tests/
 ```
 
-**Replace Pattern**
+#### Replace Pattern
 ```php
 // ❌ Old pattern - doesn't work with PSR-7 request flow
 $value = $_GET['param'] ?? null;
@@ -945,7 +944,7 @@ public function process(
 
 SC_OPTIONS hooks for page visibility may not work correctly in TYPO3 v12+.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
 grep -rn "SC_OPTIONS\['t3lib/class.t3lib_page.php'\]" ext_localconf.php
 grep -rn "additionalQueryRestrictions" ext_localconf.php
@@ -1013,40 +1012,40 @@ Legend: ✅ Supported | ⚠️ Deprecated | ❌ Removed
 
 ```bash
 # v7→v8: Old database API
-grep -rn "TYPO3_DB\|exec_SELECTquery" Classes/
+grep -rn "TYPO3_DB\|exec_SELECTquery" Classes/ Tests/
 
 # v8→v9: Old routing
 grep -rn "tx_realurl\|cooluri\|sys_domain"
 
 # v9→v10: Signal/Slot
-grep -rn "SignalSlotDispatcher\|->connect\(" Classes/
+grep -rn "SignalSlotDispatcher\|->connect\(" Classes/ Tests/
 
 # v10→v11: Old Fluid
-grep -rn "setTemplatePathAndFilename" Classes/
+grep -rn "setTemplatePathAndFilename" Classes/ Tests/
 
 # v11→v12: PDO constants & deprecated methods
-grep -rn "PDO::PARAM_\|GeneralUtility::_GET\|itemFormElID" Classes/
+grep -rn "PDO::PARAM_\|GeneralUtility::_GET\|itemFormElID" Classes/ Tests/
 
 # v12→v13: TSFE direct access
-grep -rn "\$TSFE->fe_user\|\$TSFE->page\|\$TSFE->rootLine" Classes/
+grep -rn "\$TSFE->fe_user\|\$TSFE->page\|\$TSFE->rootLine" Classes/ Tests/
 
 # v13→v14.3: getIndpEnv() deprecation (use NormalizedParams)
-grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/
+grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Tests/ Configuration/
 
 # PHP 8.4: Implicit nullable parameters
-grep -rn '\$[a-zA-Z_]* = null)' Classes/ | grep -v '?'
+grep -rn '\$[a-zA-Z_]* = null)' Classes/ Tests/ | grep -v '?'
 
 # PHP 8.4: Old TCA items format
 grep -rn "'items'\s*=>" Configuration/TCA/ | head -20
 
 # PSR-7: Direct superglobal access
-grep -rn "\$_GET\['\|\$_POST\['" Classes/
+grep -rn "\$_GET\['\|\$_POST\['" Classes/ Tests/
 
 # SC_OPTIONS hooks (may need PSR-14 migration)
 grep -rn "SC_OPTIONS" ext_localconf.php
 
 # All versions: Full deprecation scan
-grep -rn "@deprecated\|trigger_error.*E_USER_DEPRECATED" Classes/
+grep -rn "@deprecated\|trigger_error.*E_USER_DEPRECATED" Classes/ Tests/
 ```
 
 ---
@@ -1079,13 +1078,13 @@ When upgrading extensions, tests often need adjustments to work with new TYPO3 v
 
 In TYPO3 v12+, singleton services may persist state between tests. Reset the Container before each test:
 
-**Problem Pattern**
+#### Problem Pattern
 ```php
 // Tests pass individually but fail when run together
 // due to state pollution from singleton services
 ```
 
-**Fix Pattern**
+#### Fix Pattern
 ```php
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Core\Bootstrap;
@@ -1093,10 +1092,10 @@ use TYPO3\CMS\Core\Core\Bootstrap;
 protected function setUp(): void
 {
     parent::setUp();
-    
+
     // Reset Container to ensure clean state
     GeneralUtility::resetSingletonInstances([]);
-    
+
     // Flush all caches for complete reset
     Bootstrap::initializeBackendRouter();
 }
@@ -1106,7 +1105,7 @@ protected function setUp(): void
 
 When testing features that use session storage (e.g., context matching), disable sessions in fixtures:
 
-**CSV Fixture Pattern**
+#### CSV Fixture Pattern
 ```csv
 # tx_myext_records.csv
 # Set use_session=0 to prevent session state from persisting between tests
@@ -1121,7 +1120,7 @@ When testing features that use session storage (e.g., context matching), disable
 
 When supporting `^12.4 || ^13.4`, PHPUnit configuration may need adjustments:
 
-**Coverage Driver Consideration**
+#### Coverage Driver Consideration
 ```xml
 <!-- Build/phpunit/UnitTests.xml -->
 <phpunit>
@@ -1134,7 +1133,7 @@ When supporting `^12.4 || ^13.4`, PHPUnit configuration may need adjustments:
 </phpunit>
 ```
 
-**CI without Coverage Driver**
+#### CI without Coverage Driver
 ```bash
 # If no coverage driver installed, use --no-coverage flag
 ./vendor/bin/phpunit --no-coverage
@@ -1168,14 +1167,14 @@ fi
 
 Playwright E2E tests may need adjustments for TYPO3 version differences:
 
-**Locator Changes**
+#### Locator Changes
 ```typescript
 // TYPO3 v12 vs v13 may have different CSS selectors
 // Use data-testid attributes for stability
 await page.locator('[data-testid="login-submit"]').click();
 ```
 
-**Timeout Adjustments**
+#### Timeout Adjustments
 ```typescript
 // TYPO3 v13 backend may take longer to initialize
 test.setTimeout(60000); // 60 seconds for complex backend operations
@@ -1250,12 +1249,12 @@ TYPO3 extensions often use Symfony components directly. Be aware of these deprec
 
 The `Symfony\Component\PropertyInfo\Type` class and its constants are deprecated since Symfony 7.3.
 
-**Search Pattern**
+#### Search Pattern
 ```bash
-grep -rn "PropertyInfo\\Type\|Type::BUILTIN_TYPE_" Classes/
+grep -rn "PropertyInfo\\Type\|Type::BUILTIN_TYPE_" Classes/ Tests/
 ```
 
-**Replace**
+#### Replace
 
 | Before (Deprecated) | After |
 |---------------------|-------|
@@ -1269,7 +1268,7 @@ grep -rn "PropertyInfo\\Type\|Type::BUILTIN_TYPE_" Classes/
 | `Type::BUILTIN_TYPE_CALLABLE` | `'callable'` |
 | `Type::BUILTIN_TYPE_ITERABLE` | `'iterable'` |
 
-**Example Migration**
+#### Example Migration
 ```php
 // Before (deprecated since Symfony 7.3)
 use Symfony\Component\PropertyInfo\Type;
@@ -1306,7 +1305,7 @@ $encoder->addType(
 }
 ```
 
-**Common Mistakes**
+#### Common Mistakes
 ```json
 // ❌ BAD: No minimum specified - breaks on older PHP
 {
@@ -1336,7 +1335,7 @@ When supporting PHP 8.2, watch for dependencies that require newer PHP versions:
 | `phpunit/phpunit` | `^12.0` | PHP ≥8.3 |
 | `phpunit/phpunit` | `^11.0` | PHP ≥8.2 |
 
-**Diagnosis Command**
+#### Diagnosis Command
 ```bash
 # Find what prevents a specific PHP version
 composer why-not php:8.2

--- a/skills/typo3-extension-upgrade/references/api-traps.md
+++ b/skills/typo3-extension-upgrade/references/api-traps.md
@@ -13,7 +13,7 @@ This bites hardest in admin tooling, cleanup scripts, and audit features that ex
 ### Search Pattern
 
 ```bash
-grep -rn "->select(\|Connection::select" Classes/ Tests/
+grep -rne "->select(\|Connection::select" Classes/ Tests/
 ```
 
 **Fix** — drop down to `QueryBuilder` and remove restrictions explicitly:

--- a/skills/typo3-extension-upgrade/references/api-traps.md
+++ b/skills/typo3-extension-upgrade/references/api-traps.md
@@ -10,10 +10,10 @@ Architectural rules and silent footguns that bite across TYPO3 v12, v13, and v14
 
 This bites hardest in admin tooling, cleanup scripts, and audit features that explicitly want to see deleted records.
 
-**Search Pattern**
+### Search Pattern
 
 ```bash
-grep -rn "->select(\|Connection::select" Classes/
+grep -rn "->select(\|Connection::select" Classes/ Tests/
 ```
 
 **Fix** — drop down to `QueryBuilder` and remove restrictions explicitly:
@@ -83,10 +83,10 @@ Mental model: `ext_localconf.php` is for "configure the framework" (DI, caches, 
 
 `GeneralUtility::callUserFunction()` instantiates the target class via `makeInstance()` **without DI**, calling the constructor with no arguments. Any class used as a userFunc target (TypoScript `userFunc`, TCA `displayCond`, custom hooks routed through callUserFunction, user-settings panels, etc.) **cannot use constructor injection** — you'll get a `TypeError: too few arguments`.
 
-**Search Pattern**
+### Search Pattern
 
 ```bash
-grep -rn "callUserFunction\|userFunc\s*=" Classes/ Configuration/
+grep -rn "callUserFunction\|userFunc\s*=" Classes/ Tests/ Configuration/
 ```
 
 **Fix options** (in order of preference):

--- a/skills/typo3-extension-upgrade/references/real-world-patterns.md
+++ b/skills/typo3-extension-upgrade/references/real-world-patterns.md
@@ -27,7 +27,7 @@ services:
 
 **Search Pattern**:
 ```bash
-grep -rn "GeneralUtility::_GET\|GeneralUtility::_POST\|GeneralUtility::_GP" Classes/
+grep -rn "GeneralUtility::_GET\|GeneralUtility::_POST\|GeneralUtility::_GP" Classes/ Tests/
 ```
 
 **v11 Pattern**:
@@ -48,7 +48,7 @@ $value = $request->getQueryParams()['tx_myext'] ?? null;
 
 **Search Pattern**:
 ```bash
-grep -rn "\$GLOBALS\['TSFE'\]" Classes/
+grep -rn "\$GLOBALS\['TSFE'\]" Classes/ Tests/
 ```
 
 **v11 Pattern**:
@@ -72,7 +72,7 @@ $pageId = $pageInfo?->getId() ?? 0;
 
 **Search Pattern**:
 ```bash
-grep -rn "createNamedParameter" Classes/
+grep -rn "createNamedParameter" Classes/ Tests/
 ```
 
 **v11 (DBAL 3.x)**:
@@ -88,6 +88,7 @@ $queryBuilder->createNamedParameter($value, Connection::PARAM_INT);
 ```
 
 **Available Constants**:
+
 | PDO Constant | DBAL Constant |
 |--------------|---------------|
 | `PDO::PARAM_INT` | `Connection::PARAM_INT` |
@@ -99,7 +100,7 @@ $queryBuilder->createNamedParameter($value, Connection::PARAM_INT);
 
 **Search Pattern**:
 ```bash
-grep -rn "itemFormElID" Classes/
+grep -rn "itemFormElID" Classes/ Tests/
 ```
 
 **v11 Pattern**:

--- a/skills/typo3-extension-upgrade/references/third-party-dependency-upgrades.md
+++ b/skills/typo3-extension-upgrade/references/third-party-dependency-upgrades.md
@@ -42,13 +42,13 @@ Search your extension's PHP code (e.g., `Classes/`, `Tests/`, `Configuration/`, 
 
 ```bash
 # Find all imports/use statements for the package namespace
-grep -rn "use Vendor\\Package\\" Classes/ Tests/ Tests/ Configuration/ Resources/
+grep -rn "use Vendor\\Package\\" Classes/ Tests/ Configuration/ Resources/
 
 # Find all method calls on objects of that type
-grep -rn "->methodName(" Classes/ Tests/ Tests/ Configuration/ Resources/
+grep -rne "->methodName(" Classes/ Tests/ Configuration/ Resources/
 
 # Find all static calls
-grep -rn "Vendor\\Package\\ClassName::" Classes/ Tests/ Tests/ Configuration/ Resources/
+grep -rn "Vendor\\Package\\ClassName::" Classes/ Tests/ Configuration/ Resources/
 ```
 
 ### Step 2: Cross-Reference Against New Version's API

--- a/skills/typo3-extension-upgrade/references/third-party-dependency-upgrades.md
+++ b/skills/typo3-extension-upgrade/references/third-party-dependency-upgrades.md
@@ -42,13 +42,13 @@ Search your extension's PHP code (e.g., `Classes/`, `Tests/`, `Configuration/`, 
 
 ```bash
 # Find all imports/use statements for the package namespace
-grep -rn "use Vendor\\Package\\" Classes/ Tests/ Configuration/ Resources/
+grep -rn "use Vendor\\Package\\" Classes/ Tests/ Tests/ Configuration/ Resources/
 
 # Find all method calls on objects of that type
-grep -rn "->methodName(" Classes/ Tests/ Configuration/ Resources/
+grep -rn "->methodName(" Classes/ Tests/ Tests/ Configuration/ Resources/
 
 # Find all static calls
-grep -rn "Vendor\\Package\\ClassName::" Classes/ Tests/ Configuration/ Resources/
+grep -rn "Vendor\\Package\\ClassName::" Classes/ Tests/ Tests/ Configuration/ Resources/
 ```
 
 ### Step 2: Cross-Reference Against New Version's API

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -96,29 +96,39 @@ $rectorConfig->sets([
 
 All 98 breakers landed in v14.0. **If your extension compiles against v14.0, it's already forward-compatible with 14.1/14.2/14.3.**
 
+**Every search below covers `Tests/` as well as `Classes/`, and that is not tidiness.** A removed class referenced from a test file does not fail one test — PHPUnit resolves the class while *loading* the suite, so the run dies before a single test executes:
+
+```
+An error occurred inside PHPUnit.
+Message:  Class "TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController" not found
+Location: Tests/Unit/Classes/Context/AbstractContextTest.php:38
+```
+
+The extension's `Classes/` was clean, the dependencies resolved, v14.3 installed — and the suite reported a total failure whose cause the prescribed searches could not see, because they looked only in `Classes/`. Measured on an upgrade that got everything else right, four times over two days. The test suite is production code for the purposes of an upgrade.
+
 ### Critical (most-hit)
 
 | Change | Forge | Search | Fix |
 |---|---|---|---|
-| `TypoScriptFrontendController` class removed | #107831 | `grep -rn "TSFE\|TypoScriptFrontendController\|frontend.controller" Classes/` | Use `$request->getAttribute('frontend.page.information')`, `PageRenderer::addHeaderData()` |
+| `TypoScriptFrontendController` class removed | #107831 | `grep -rn "TSFE\|TypoScriptFrontendController\|frontend.controller" Classes/ Tests/` | Use `$request->getAttribute('frontend.page.information')`, `PageRenderer::addHeaderData()` |
 | Fluid 5 strict VH typing | #108148 | `grep -rL "function render.*:" Classes/ViewHelpers/` | Add typed args + `render(): string` |
-| Fluid VH `renderStatic()` removed | #108148 | `grep -rn "renderStatic" Classes/` | Non-static `render()` |
-| Fluid `StandaloneView`, `TemplateView` removed | #105377 | `grep -rn "StandaloneView\|AbstractTemplateView" Classes/` | `Core\View\ViewFactoryInterface` |
+| Fluid VH `renderStatic()` removed | #108148 | `grep -rn "renderStatic" Classes/ Tests/` | Non-static `render()` |
+| Fluid `StandaloneView`, `TemplateView` removed | #105377 | `grep -rn "StandaloneView\|AbstractTemplateView" Classes/ Tests/` | `Core\View\ViewFactoryInterface` |
 | Fluid underscore-prefixed variables forbidden | #108148 | `grep -rEn '\{_[a-zA-Z]' Resources/Private/` | Rename variables |
-| Extbase annotation namespace removed | #107229 | `grep -rn "@Extbase\\\\Annotation" Classes/` | PHP attributes `#[Validate]`, `#[IgnoreValidation]` |
-| Magic repo finders removed | #105377 | `grep -rn "->findBy[A-Z]\|->findOneBy[A-Z]\|->countBy[A-Z]" Classes/` | `createQuery()` builder |
-| `HashService` (Extbase) removed | #105377 | `grep -rn "HashService\|GeneralUtility::hmac(" Classes/` | Core cipher service (#108002) |
+| Extbase annotation namespace removed | #107229 | `grep -rn "@Extbase\\\\Annotation" Classes/ Tests/` | PHP attributes `#[Validate]`, `#[IgnoreValidation]` |
+| Magic repo finders removed | #105377 | `grep -rn "->findBy[A-Z]\|->findOneBy[A-Z]\|->countBy[A-Z]" Classes/ Tests/` | `createQuery()` builder |
+| `HashService` (Extbase) removed | #105377 | `grep -rn "HashService\|GeneralUtility::hmac(" Classes/ Tests/` | Core cipher service (#108002) |
 | TCA `subtype_value_field` / `subtypes_addlist` removed | #105377 | `grep -rn "subtype_value_field\|subtypes_addlist" Configuration/TCA/` | Record-type flex-form handling |
 | TCA `control.searchFields` removed | #106972 | `grep -rn "searchFields" Configuration/TCA/` | Configurable search TCA |
 | TCA `eval=year` removed | #98070 | `grep -rn "'eval'.*year" Configuration/TCA/` | integer field |
 | TCA `pages.url` field removed | #17406 | `grep -rn "pages\\.url" Configuration/TCA/` | typolink page type |
 | `tt_content.list_type` removed | #105538, #105377 | `grep -rn "list_type\|addPlugin" Configuration/` | CType-only plugins; drop 2nd/3rd args of `addPlugin()` |
 | EXT:form hooks removed (10 hooks) | many | `grep -rn "'afterBuildingFinished'\|beforeFormCreate\|beforeFormSave\|beforeFormDelete\|beforeFormDuplicate\|initializeFormElement\|beforeRemoveFromParentRenderable\|afterInitializeCurrentPage\|afterSubmit\|beforeRendering" ext_localconf.php Classes/` | PSR-14 events |
-| `TypolinkBuilder` signature changed | #106405 | `grep -rn "extends AbstractTypolinkBuilder\|TypolinkBuilder" Classes/` | Implement `TypolinkBuilderInterface` |
+| `TypolinkBuilder` signature changed | #106405 | `grep -rn "extends AbstractTypolinkBuilder\|TypolinkBuilder" Classes/ Tests/` | Implement `TypolinkBuilderInterface` |
 | Bootstrap Modal → native `<dialog>` | #107443 | `grep -rn "Modal.advanced\|bootstrap.*modal" Resources/Public/JavaScript/` | Native `<dialog>` API |
-| `MailMessage->send()` removed | #108097 | `grep -rn "->send()" Classes/` (filter for MailMessage) | Dispatch via Mailer service |
+| `MailMessage->send()` removed | #108097 | `grep -rn "->send()" Classes/ Tests/` (filter for MailMessage) | Dispatch via Mailer service |
 | HMAC algorithm SHA1 → SHA256 | #106307 | automatic via Rector | Rotate existing HMACs if persisted |
-| `LoginProviderInterface::render()` → `modifyView()` | internal | `grep -rn "LoginProviderInterface" Classes/` | Implement `modifyView()` |
+| `LoginProviderInterface::render()` → `modifyView()` | internal | `grep -rn "LoginProviderInterface" Classes/ Tests/` | Implement `modifyView()` |
 | `composer.json` required in classic mode | #108310 | check presence in project root | Create `composer.json` with extension autoload |
 | CSS/JS concat & compression removed | #108055 | `grep -rn "concatenateCss\|concatenateJs\|compressCss\|compressJs" Configuration/TypoScript/` | Use build tools (webpack/vite) |
 | Frontend HTTP compression removed | #107943 | check TypoScript `config.compressionLevel` | Delegate to web server (nginx/Apache) |
@@ -130,7 +140,7 @@ These are **not** v14.0 breakers — code keeps working — but you should migra
 
 | Change | Forge / Source | Search | Fix |
 |---|---|---|---|
-| `GeneralUtility::getIndpEnv()` deprecated (v14.3) | `cms-core` v14.3 — `Classes/Utility/GeneralUtility.php` `@deprecated` annotation | `grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Configuration/` | `$request->getAttribute('normalizedParams')->getRemoteAddress()` etc. — see `api-changes.md` |
+| `GeneralUtility::getIndpEnv()` deprecated (v14.3) | `cms-core` v14.3 — `Classes/Utility/GeneralUtility.php` `@deprecated` annotation | `grep -rn "GeneralUtility::getIndpEnv\|::getIndpEnv(" Classes/ Tests/ Configuration/` | `$request->getAttribute('normalizedParams')->getRemoteAddress()` etc. — see `api-changes.md` |
 
 > ⚠️ **AI-assistant warning**: Don't trust Gemini Code Assist on `getIndpEnv()` deprecation timing. It has hallucinated v13.0 deprecation / v14.0 removal, and falsely claimed `NormalizedParams::createFromServerParams()` was removed in v14.0 in favour of a non-existent `NormalizedParamsFactory`. All three claims are wrong — verified false against `typo3/cms-core` v14.3.0 vendor source. Always grep the `@deprecated` annotation in `vendor/typo3/cms-core/` to confirm.
 
@@ -388,7 +398,7 @@ vendor/bin/rector process --dry-run
 vendor/bin/fluid analyze Resources/Private/
 
 # No removed APIs remain
-grep -rnE "HashService|->findBy[A-Z]|GLOBALS\[.TSFE.\]|StandaloneView|renderStatic|subtype_value_field|control\\.searchFields" Classes/ Configuration/
+grep -rnE "HashService|->findBy[A-Z]|GLOBALS\[.TSFE.\]|StandaloneView|renderStatic|subtype_value_field|control\\.searchFields" Classes/ Tests/ Configuration/
 ```
 
 ---
@@ -413,7 +423,7 @@ See also:
 - `api-changes.md` — detailed v13→v14 API migration patterns
 - `third-party-dependency-upgrades.md` — Symfony 7.3 / Doctrine DBAL 4 / Fluid 5 / CKE 47 bump notes
 - `verification.md` — success criteria
-- TYPO3 Core Changelog 14.0–14.3: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-14.html
+- TYPO3 Core Changelog 14.0–14.3: <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-14.html>
 
 ## SingletonInterface deprecation (TYPO3 v14)
 

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -96,7 +96,7 @@ $rectorConfig->sets([
 
 All 98 breakers landed in v14.0. **If your extension compiles against v14.0, it's already forward-compatible with 14.1/14.2/14.3.**
 
-**Every search below covers `Tests/` as well as `Classes/`, and that is not tidiness.** A removed class referenced from a test file does not fail one test — PHPUnit resolves the class while *loading* the suite, so the run dies before a single test executes:
+**Every search below that reads PHP covers `Tests/` as well as `Classes/`, and that is not tidiness.** A removed class referenced from a test file does not fail one test — PHPUnit resolves the class while *loading* the suite, so the run dies before a single test executes:
 
 ```
 An error occurred inside PHPUnit.
@@ -105,6 +105,8 @@ Location: Tests/Unit/Classes/Context/AbstractContextTest.php:38
 ```
 
 The extension's `Classes/` was clean, the dependencies resolved, v14.3 installed — and the suite reported a total failure whose cause the prescribed searches could not see, because they looked only in `Classes/`. Measured on an upgrade that got everything else right, four times over two days. The test suite is production code for the purposes of an upgrade.
+
+The rows that search `Configuration/`, `Resources/Private/` or a single subdirectory of `Classes/` are unchanged: a Fluid template or a TCA file has no counterpart under `Tests/`.
 
 ### Critical (most-hit)
 
@@ -116,7 +118,7 @@ The extension's `Classes/` was clean, the dependencies resolved, v14.3 installed
 | Fluid `StandaloneView`, `TemplateView` removed | #105377 | `grep -rn "StandaloneView\|AbstractTemplateView" Classes/ Tests/` | `Core\View\ViewFactoryInterface` |
 | Fluid underscore-prefixed variables forbidden | #108148 | `grep -rEn '\{_[a-zA-Z]' Resources/Private/` | Rename variables |
 | Extbase annotation namespace removed | #107229 | `grep -rn "@Extbase\\\\Annotation" Classes/ Tests/` | PHP attributes `#[Validate]`, `#[IgnoreValidation]` |
-| Magic repo finders removed | #105377 | `grep -rn "->findBy[A-Z]\|->findOneBy[A-Z]\|->countBy[A-Z]" Classes/ Tests/` | `createQuery()` builder |
+| Magic repo finders removed | #105377 | `grep -rne "->findBy[A-Z]\|->findOneBy[A-Z]\|->countBy[A-Z]" Classes/ Tests/` | `createQuery()` builder |
 | `HashService` (Extbase) removed | #105377 | `grep -rn "HashService\|GeneralUtility::hmac(" Classes/ Tests/` | Core cipher service (#108002) |
 | TCA `subtype_value_field` / `subtypes_addlist` removed | #105377 | `grep -rn "subtype_value_field\|subtypes_addlist" Configuration/TCA/` | Record-type flex-form handling |
 | TCA `control.searchFields` removed | #106972 | `grep -rn "searchFields" Configuration/TCA/` | Configurable search TCA |
@@ -126,7 +128,7 @@ The extension's `Classes/` was clean, the dependencies resolved, v14.3 installed
 | EXT:form hooks removed (10 hooks) | many | `grep -rn "'afterBuildingFinished'\|beforeFormCreate\|beforeFormSave\|beforeFormDelete\|beforeFormDuplicate\|initializeFormElement\|beforeRemoveFromParentRenderable\|afterInitializeCurrentPage\|afterSubmit\|beforeRendering" ext_localconf.php Classes/` | PSR-14 events |
 | `TypolinkBuilder` signature changed | #106405 | `grep -rn "extends AbstractTypolinkBuilder\|TypolinkBuilder" Classes/ Tests/` | Implement `TypolinkBuilderInterface` |
 | Bootstrap Modal → native `<dialog>` | #107443 | `grep -rn "Modal.advanced\|bootstrap.*modal" Resources/Public/JavaScript/` | Native `<dialog>` API |
-| `MailMessage->send()` removed | #108097 | `grep -rn "->send()" Classes/ Tests/` (filter for MailMessage) | Dispatch via Mailer service |
+| `MailMessage->send()` removed | #108097 | `grep -rne "->send()" Classes/ Tests/` (filter for MailMessage) | Dispatch via Mailer service |
 | HMAC algorithm SHA1 → SHA256 | #106307 | automatic via Rector | Rotate existing HMACs if persisted |
 | `LoginProviderInterface::render()` → `modifyView()` | internal | `grep -rn "LoginProviderInterface" Classes/ Tests/` | Implement `modifyView()` |
 | `composer.json` required in classic mode | #108310 | check presence in project root | Create `composer.json` with extension autoload |


### PR DESCRIPTION
Every search in these references was written against `Classes/`. The word `Tests/` did not appear once in the v13→v14 reference, and nowhere in `api-changes.md` either.

That is not an omission of tidiness. A removed class referenced from a test file does not fail one test — PHPUnit resolves it while *loading* the suite, so the run dies before a single test executes, and the extension reports a total test failure whose cause the prescribed searches cannot see.

**Measured.** In [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), on a case that upgrades a real extension to v14, four trials across two separate days did everything else right — dependencies resolved, `v14.3.6` installed, `Classes/` clean — and every one of them ended in

```
An error occurred inside PHPUnit.
Message:  Class "TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController" not found
Location: Tests/Unit/Classes/Context/AbstractContextTest.php:38
```

against a table row in this very file that names that exact class, with a `grep` that looks only in `Classes/`. The bare agent, without these references, never got as far as resolving.

Fifty searches now name `Classes/ Tests/`. Subdirectory-scoped ones (`Classes/Command/`, `Classes/Controller/`, `Classes/Task/`, `Classes/Hook/`) are left alone, because a mirrored `Tests/` path is not where those live. The v13→v14 reference says why in a paragraph before the table: for the purposes of an upgrade, the test suite is production code.

**Pre-existing lint.** The touched files carried 91 markdownlint findings older than this change — 86 bold lines used as headings in `api-changes.md`, two more in `api-traps.md`, a table without surrounding blank lines, a bare URL, a blockquote split by a blank line. `main` is red on them today; the hook only sees a file once someone edits it. Fixed here from the linter's own line numbers, so nothing else moved. That is most of the diff.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
