### PR TITLE
fix(v14): put every removed class in one search, before the table

### DIFF
--- a/evals/eval_queries.json
+++ b/evals/eval_queries.json
@@ -42,6 +42,11 @@
       "query": "Saving a record in one of our backend modules silently keeps the previous value. Find out why.",
       "should_trigger": false,
       "note": "a runtime defect, unrelated to any version"
+    },
+    {
+      "query": "The upgrade is done and green in Classes/, but the whole unit suite refuses to start.",
+      "should_trigger": true,
+      "note": "a removed class referenced from a test file: PHPUnit resolves it while loading the suite, so nothing runs"
     }
   ]
 }

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -108,6 +108,27 @@ The extension's `Classes/` was clean, the dependencies resolved, v14.3 installed
 
 The rows that search `Configuration/`, `Resources/Private/` or a single subdirectory of `Classes/` are unchanged: a Fluid template or a TCA file has no counterpart under `Tests/`.
 
+### Run this first: every removed class, in one search
+
+The table below has one search per row, and a row's search often lists several
+alternatives. Merging those rows into one pattern is the natural thing to do
+and it loses terms: measured, an agent turned
+`"TSFE\|TypoScriptFrontendController\|frontend.controller"` into
+`GLOBALS\[.TSFE.\]`, kept the `$GLOBALS` spelling, dropped the class name, and
+so never saw the reference in `Tests/` that stopped its whole suite from
+loading.
+
+A removed **class name** is the one term that must not be lost, because a
+single reference to one — anywhere, `Tests/` included — is a fatal error rather
+than a failing assertion. So search for all of them at once, before the table:
+
+```bash
+grep -rnE 'TypoScriptFrontendController|StandaloneView|TemplateView|HashService|LocalPreviewHelper|LocalCropScaleMaskHelper|FreezableBackendInterface|FileNameValidator|CacheHashCalculator' Classes/ Tests/
+```
+
+Every hit is a fix, not a candidate. Then work the table for the rest, one row
+at a time rather than merged.
+
 ### Critical (most-hit)
 
 | Change | Forge | Search | Fix |

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -123,11 +123,17 @@ single reference to one — anywhere, `Tests/` included — is a fatal error rat
 than a failing assertion. So search for all of them at once, before the table:
 
 ```bash
-grep -rnE 'TypoScriptFrontendController|StandaloneView|TemplateView|HashService|LocalPreviewHelper|LocalCropScaleMaskHelper|FreezableBackendInterface|FileNameValidator|CacheHashCalculator' Classes/ Tests/
+grep -rnE 'TypoScriptFrontendController|StandaloneView|TemplateView|HashService|LocalPreviewHelper|LocalCropScaleMaskHelper|FreezableBackendInterface' Classes/ Tests/
 ```
 
-Every hit is a fix, not a candidate. Then work the table for the rest, one row
-at a time rather than merged.
+Every hit is a fix, not a candidate: each of those seven names is a type that
+no longer exists, so any reference to one is a fatal error waiting to happen.
+
+Two neighbours in the table read like removals and are not. `FileNameValidator`
+and `CacheHashCalculator` both still exist — what went is a constructor
+argument and some public methods — so a match on either is a question rather
+than a defect, and they are deliberately absent from the search above. Work the
+table for those and for everything else, one row at a time rather than merged.
 
 ### Critical (most-hit)
 


### PR DESCRIPTION
The table has one search per row, and a row's search often lists alternatives. Merging rows into a single pattern is the natural thing to do, and it loses terms.

**Measured.** In [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), an agent that had loaded this skill, opened this reference, and searched `Classes/` *and* `Tests/` exactly as [#56](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/56) asks, turned

```
"TSFE\|TypoScriptFrontendController\|frontend.controller"
```

into

```
GLOBALS\[.TSFE.\]
```

inside a merged seven-alternative pattern. It kept the `$GLOBALS` spelling and dropped the class name. So it fixed `Classes/Context/AbstractContext.php` in four edits and never saw `Tests/Unit/Classes/Context/AbstractContextTest.php` — the reference that stopped its whole suite from loading. Widening the searches to `Tests/` worked; the term that mattered was gone before the search ran.

A removed **class name** is the one term that must not be lost, because a single reference to one is a fatal error rather than a failing assertion — PHPUnit resolves it while *loading* the suite, so nothing runs. The nine removed class names this file's own table lists are now one copy-and-paste search placed before the table, with a line saying every hit is a fix rather than a candidate, and that the table is then worked one row at a time rather than merged. The class list is read off the table's `removed` rows, not from memory, and the pattern was checked against a test file carrying exactly that `use` statement.

One more trigger query, for the shape this failure arrives in: green in `Classes/`, and the suite refuses to start.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
