### PR TITLE
fix(v14): say what to write when a removed class sits in a type declaration

### DIFF
--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -138,8 +138,10 @@ table for those and for everything else, one row at a time rather than merged.
 #### When the hit is inside a type declaration
 
 A removed class in a property, parameter or return type cannot be replaced by
-`object`. PHP rejects a union that mixes `object` with a class type, at compile
-time, for the whole file:
+`object` **while another class type stays in the same union**. PHP rejects a
+union that mixes `object` with a class type, at compile time, for the whole
+file. Alone, `object` and `object|null` are perfectly valid — it is the
+combination that is refused:
 
 ```
 Fatal error: Type FrontendUserAuthentication|object|null contains both object
@@ -152,13 +154,18 @@ symptom as before the fix, one cause further on. Write the replacement type,
 or drop the declaration entirely and keep the docblock:
 
 ```php
-// Wrong: object beside a class type
+use Psr\Http\Message\ServerRequestInterface;
+
+// Wrong: object beside a class type that stayed
 private FrontendUserAuthentication|object|null $context = null;
 
-// Either name the type that replaced it
+// Fine, if nothing else remains in the union
+private ?object $context = null;
+
+// Better: name the type that replaced it
 private ?ServerRequestInterface $request = null;
 
-// or leave it untyped and say so in the docblock
+// Or leave it untyped and say so in the docblock
 /** @var mixed the v13 context object, gone in v14 */
 private $context = null;
 ```

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -135,6 +135,34 @@ argument and some public methods — so a match on either is a question rather
 than a defect, and they are deliberately absent from the search above. Work the
 table for those and for everything else, one row at a time rather than merged.
 
+#### When the hit is inside a type declaration
+
+A removed class in a property, parameter or return type cannot be replaced by
+`object`. PHP rejects a union that mixes `object` with a class type, at compile
+time, for the whole file:
+
+```
+Fatal error: Type FrontendUserAuthentication|object|null contains both object
+and a class type, which is redundant
+```
+
+Measured: an agent that had found the reference in a test file and removed the
+class name got exactly this, and the suite still failed to load — the same
+symptom as before the fix, one cause further on. Write the replacement type,
+or drop the declaration entirely and keep the docblock:
+
+```php
+// Wrong: object beside a class type
+private FrontendUserAuthentication|object|null $context = null;
+
+// Either name the type that replaced it
+private ?ServerRequestInterface $request = null;
+
+// or leave it untyped and say so in the docblock
+/** @var mixed the v13 context object, gone in v14 */
+private $context = null;
+```
+
 ### Critical (most-hit)
 
 | Change | Forge | Search | Fix |


### PR DESCRIPTION
[#57](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/57) got agents to *find* the reference. This is about what they do with it.

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals): an agent found the removed class in a test file, edited it, and the suite still would not load — the same symptom as before, one cause further on:

```
Fatal error: Type FrontendUserAuthentication|object|null contains both object
and a class type, which is redundant
```

PHP rejects a union that mixes `object` with a class type, at compile time, for the whole file. Reproduced outside TYPO3 with `php -r 'class A{} function f(A|object|null $x){}'`, which fails identically — a language rule, not a framework one.

The new subsection sits directly under the one-search block, where an agent arrives having just found a hit: name the replacement type, or drop the declaration and keep the docblock, with the wrong form shown beside them.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
