### PR TITLE
fix(v14): say there is no ^14.4, because that is what gets written

### DIFF
--- a/evals/eval_queries.json
+++ b/evals/eval_queries.json
@@ -47,6 +47,11 @@
       "query": "The upgrade is done and green in Classes/, but the whole unit suite refuses to start.",
       "should_trigger": true,
       "note": "a removed class referenced from a test file: PHPUnit resolves it while loading the suite, so nothing runs"
+    },
+    {
+      "query": "composer update says my constraint conflicts with the temporary one and nothing installs. We are going to v14.",
+      "should_trigger": true,
+      "note": "usually a constraint written as ^14.4, a minor that does not exist"
     }
   ]
 }

--- a/evals/eval_queries.json
+++ b/evals/eval_queries.json
@@ -49,9 +49,9 @@
       "note": "a removed class referenced from a test file: PHPUnit resolves it while loading the suite, so nothing runs"
     },
     {
-      "query": "composer update says my constraint conflicts with the temporary one and nothing installs. We are going to v14.",
+      "query": "Our extension's composer.json now names v14, but composer refuses it — the constraint conflicts with the temporary one and nothing installs.",
       "should_trigger": true,
-      "note": "usually a constraint written as ^14.4, a minor that does not exist"
+      "note": "usually the extension's own constraint written as ^14.4, a minor that does not exist"
     }
   ]
 }

--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -8,6 +8,23 @@
 
 ## Version constraints
 
+> **The LTS minor is `.3`, not `.4`. There is no `^14.4`.**
+>
+> v11.5, v12.4 and v13.4 made the last minor of each major the LTS, so the next
+> one in the rhythm looks like `14.4`. It does not exist: v14's LTS is
+> **14.3**, released 2026-04-21, and the newest v14 release is 14.3.6.
+> `^14.4` matches nothing, so `composer update` fails with
+>
+> ```
+> Root composer.json requires typo3/cms-backend ^12.4 || ^13.4 || ^14.4,
+> found typo3/cms-backend[v12.4.0, ..., v13.4.34] but it conflicts with your
+> temporary update constraint
+> ```
+>
+> Measured: of six upgrade runs, the four that guessed the constraint wrote
+> `^12.4 || ^13.4 || ^14.4` and never installed anything; the two that used the
+> form below wrote `^13.4 || ^14.3` and resolved v14.3.6.
+
 ### composer.json (v14-only)
 
 ```json


### PR DESCRIPTION
The reference already showed the right constraint twice, prominently, in its first section. It never said which *wrong* one is attractive — and the wrong one won four times out of six.

**Measured** across six upgrade runs on one case in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), reading `composer.after.json` per trial:

| what the agent wrote | trials | outcome |
|---|---|---|
| `^13.4 \|\| ^14.3` — the documented dual form | 2 | resolved, installed `v14.3.6` |
| `^12.4 \|\| ^13.4 \|\| ^14.4` — the guess | 4 | `RESOLVE=failed`, nothing installed |

```
Root composer.json requires typo3/cms-backend ^12.4 || ^13.4 || ^14.4,
found typo3/cms-backend[v12.4.0, ..., v13.4.34] but it conflicts with your
temporary update constraint
```

The guess is not careless. v11.5, v12.4 and v13.4 all made the last minor of their major the LTS, so `14.4` is that rhythm continued. v14 breaks it: the LTS is **14.3**, and `get.typo3.org/api/v1/major/14/release/latest` reports `14.3.6` — checked, not remembered.

So the section now names the wrong value *before* the right one and says why it looks right. A reference that states the correct answer without naming the attractive wrong answer loses to the pattern.

One more trigger query, for the shape this arrives in: composer refusing the temporary constraint with nothing installed.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
