### PR TITLE
fix(workflow): put the constraint in the step that writes it

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -21,7 +21,7 @@ Extension code only, not project/core upgrades.
 
 1. Complete planning phase (consult `references/pre-upgrade.md`)
 2. Create feature branch (verify git is clean)
-3. Update `composer.json` constraints for target version
+3. Update `composer.json` constraints for the target version. **v14's LTS minor is 3: write `^14.3`, never `^14.4`** — `^13.4 || ^14.3` to support both. v11.5, v12.4 and v13.4 make `14.4` look like the next in line; it matches no release and `composer update` then installs nothing. Constraints for every version pair: `references/upgrade-v13-to-v14.md`
 4. **Audit third-party dependencies** for major version changes (consult `references/third-party-dependency-upgrades.md`)
 5. Run `rector process --dry-run` then review and apply
 6. Run `fractor process --dry-run` then review and apply

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -21,7 +21,7 @@ Extension code only, not project/core upgrades.
 
 1. Complete planning phase (consult `references/pre-upgrade.md`)
 2. Create feature branch (verify git is clean)
-3. Update `composer.json` constraints for the target version. **v14's LTS minor is 3: write `^14.3`, never `^14.4`** — `^13.4 || ^14.3` to support both. v11.5, v12.4 and v13.4 make `14.4` look like the next in line; it matches no release and `composer update` then installs nothing. Constraints for every version pair: `references/upgrade-v13-to-v14.md`
+3. Update `composer.json` constraints for the target version. **v14's LTS minor is 3: write `^14.3`, never `^14.4`** — `^13.4 || ^14.3` to support both. v11.5, v12.4 and v13.4 make `14.4` look like the next in line; it matches no release, so `composer update` fails dependency resolution, exits non-zero and installs nothing. Constraints for every version pair: `references/upgrade-v13-to-v14.md`
 4. **Audit third-party dependencies** for major version changes (consult `references/third-party-dependency-upgrades.md`)
 5. Run `rector process --dry-run` then review and apply
 6. Run `fractor process --dry-run` then review and apply


### PR DESCRIPTION
The warning added in [#59](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/59) lives in `references/upgrade-v13-to-v14.md` — and the trial that needed it never opened a reference.

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), three trials of one case, all carrying that fix:

| what the agent read | what it wrote | outcome |
|---|---|---|
| `upgrade-v13-to-v14.md` | `^13.4 \|\| ^14.3` | resolved, installed `v14.3.6` |
| `upgrade-v13-to-v14.md` | `^12.4 \|\| ^13.4` | no v14 at all |
| **nothing** | `^14.4` | nothing installed |

Step 3 of the Core Workflow read *"Update `composer.json` constraints for target version"* and named no value. That is the line an agent acts on when it opens nothing, so the value belongs there: `^14.3`, never `^14.4`, and `^13.4 || ^14.3` for both.

The reference keeps the full table and the composer failure output. This is the one number the step cannot be performed without.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
