### PR TITLE
fix(workflow): a green suite on the old version proves nothing

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -28,8 +28,17 @@ Extension code only, not project/core upgrades.
 7. Run `php-cs-fixer fix`
 8. Run `phpstan analyse` **against each supported dependency version** and fix errors
 9. Run `phpunit` and fix tests
-10. Test in target TYPO3 version(s)
+10. **Install the target version and run the suite against it.** A green suite
+    on the version already installed proves nothing about the target — that is
+    the old code passing old tests. Install first, then test:
+    `composer update --with typo3/cms-core:^14.3 -W && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml`
 11. Verify success criteria (consult `references/verification.md`)
+
+**Done means the suite passes with the target version installed.** Not that the
+constraint was widened, and not that the suite is green where it was already
+green. A removed class referenced anywhere — `Tests/` included — stops PHPUnit
+while it loads the suite, so an upgrade can look finished and fail entirely at
+the first run against the new version.
 
 ## When NOT to Apply Automatically
 

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -31,14 +31,22 @@ Extension code only, not project/core upgrades.
 10. **Install the target version and run the suite against it.** A green suite
     on the version already installed proves nothing about the target — that is
     the old code passing old tests. Install first, then test:
-    `composer update --with typo3/cms-core:^14.3 -W && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml`
+    `composer update "typo3/*" --with typo3/cms-core:^14.3 -W && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml`
+    The package argument matters: without it `composer update` moves every
+    dependency, and the test result then depends on upgrades that have nothing
+    to do with TYPO3. `-W` lets the TYPO3 packages' own dependencies follow.
 11. Verify success criteria (consult `references/verification.md`)
 
 **Done means the suite passes with the target version installed.** Not that the
 constraint was widened, and not that the suite is green where it was already
-green. A removed class referenced anywhere — `Tests/` included — stops PHPUnit
-while it loads the suite, so an upgrade can look finished and fail entirely at
-the first run against the new version.
+green.
+
+Where a removed class is referenced decides when it bites. In an `import`, a
+parent class, a property or a signature it is resolved while PHPUnit *loads*
+the suite, so nothing runs at all and the failure looks nothing like a test
+failure. Referenced only inside a method body, it fails when that one test
+executes, and the rest of the suite still passes — which is the more
+comfortable failure and the easier one to miss in a summary line.
 
 ## When NOT to Apply Automatically
 


### PR DESCRIPTION
Step 10 said *"Test in target TYPO3 version(s)"* and named no command, so it was performed against the version already installed.

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals). Two trials of one upgrade case did exactly the right thing by their own lights: widened the constraint to `^13.4 || ^14.3`, ran the suite, and got

```
OK (719 tests, 1176 assertions)
```

Their entire diff is `composer.json`, `ext_emconf.php` and three XLIFF files. No migration — because nothing asked for one. The suite was green.

It was green **on v13**: the old code passing old tests. The extension had never been installed against v14.3. Installed against it, the same suite does not start at all, because a removed class is still referenced from `Tests/`, and PHPUnit resolves it while loading.

So step 10 now carries the command that installs the target and runs the suite against it, and the workflow states its exit condition: **done means the suite passes with the target version installed** — not that the constraint was widened, and not that the suite is green where it was already green.

Companion to [#60](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/60), which fixed the constraint those trials now get right. Getting the constraint right is what made this failure mode visible: before, they never resolved far enough to stop early.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
