### PR TITLE
fix: make eight refused checks execute

### DIFF
--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -14,11 +14,13 @@ mechanical:
   # keep testing/CI tooling under Build/). Build/rector/rector.php is the
   # Netresearch default when using a split Build/ structure.
   #
-  # All checks here use `command` checkpoints that loop over candidate paths
-  # and only `grep` files that actually exist — `grep -l a b c` exits with
+  # The content checks here use `script` checkpoints that loop over candidate
+  # paths and only `grep` files that actually exist — `grep -l a b c` exits with
   # status 2 when any listed file is missing, which would otherwise mask real
-  # matches in other candidates. The runner's brace-expansion in `file_exists`
-  # is used for TU-01/TU-04 since those are pure existence checks.
+  # matches in other candidates. A loop needs `;`/`&&`, which the runner's
+  # one-line allowlist refuses, so the body is a `type: script` literal block.
+  # The runner's brace-expansion in `file_exists` is used for TU-01/TU-04/TU-37
+  # since those are pure existence checks.
   - id: TU-01
     type: file_exists
     target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
@@ -26,14 +28,22 @@ mechanical:
     desc: "rector.php should exist for automated code migration (root or Build/ subdir)"
 
   - id: TU-02
-    type: command
-    pattern: 'for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0; done; exit 1'
+    type: script
+    command: |
+      for f in rector.php Build/rector.php Build/rector/rector.php; do
+        [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0
+      done
+      exit 1
     severity: warning
     desc: "Rector config should use TYPO3 level sets for version upgrades"
 
   - id: TU-03
-    type: command
-    pattern: 'for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && grep -q "RectorConfig" "$f" && exit 0; done; exit 1'
+    type: script
+    command: |
+      for f in rector.php Build/rector.php Build/rector/rector.php; do
+        [ -f "$f" ] && grep -q "RectorConfig" "$f" && exit 0
+      done
+      exit 1
     severity: warning
     desc: "Rector config should use modern RectorConfig format"
 
@@ -45,20 +55,39 @@ mechanical:
     desc: "fractor.php should exist for TypoScript/Fluid migration (root or Build/ subdir)"
 
   - id: TU-05
-    type: command
-    pattern: 'for f in fractor.php Build/fractor.php Build/fractor/fractor.php; do [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0; done; exit 1'
+    type: script
+    command: |
+      for f in fractor.php Build/fractor.php Build/fractor/fractor.php; do
+        [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0
+      done
+      exit 1
     severity: info
     desc: "Fractor config should use TYPO3 level sets"
 
   - id: TU-56
-    type: command
-    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -q "UP_TO_TYPO3_14" "$cfg" && exit 0; grep -qE "UP_TO_TYPO3_1[0-3]" "$cfg" && exit 1; exit 0'
+    type: script
+    command: |
+      cfg=""
+      for f in rector.php Build/rector.php Build/rector/rector.php; do
+        [ -f "$f" ] && cfg="$f" && break
+      done
+      [ -z "$cfg" ] && exit 0
+      grep -q "UP_TO_TYPO3_14" "$cfg" && exit 0
+      grep -qE "UP_TO_TYPO3_1[0-3]" "$cfg" && exit 1
+      exit 0
     severity: warning
     desc: "Rector Typo3LevelSetList should target the current LTS (UP_TO_TYPO3_14) — a stale set (e.g. UP_TO_TYPO3_13) passes TU-02 but silently skips all v14 migrations during the dry-run"
 
   - id: TU-57
-    type: command
-    pattern: 'cfg=""; for f in rector.php Build/rector.php Build/rector/rector.php; do [ -f "$f" ] && cfg="$f" && break; done; [ -z "$cfg" ] && exit 0; grep -q "UP_TO_PHP_" "$cfg" && exit 0; exit 1'
+    type: script
+    command: |
+      cfg=""
+      for f in rector.php Build/rector.php Build/rector/rector.php; do
+        [ -f "$f" ] && cfg="$f" && break
+      done
+      [ -z "$cfg" ] && exit 0
+      grep -q "UP_TO_PHP_" "$cfg" && exit 0
+      exit 1
     severity: info
     desc: "Rector PHP LevelSetList should be configured and target the minimum supported PHP version (the floor) — targeting the ceiling would rewrite code with newer-version syntax and break the floor. Verify the PHP ceiling statically with PHPStan/CI, not Rector"
 
@@ -292,10 +321,23 @@ mechanical:
 
   # === THIRD-PARTY DEPENDENCY VERSION COMPATIBILITY ===
   - id: TU-60
-    type: command
-    pattern: "php -r \"\\$c=json_decode(file_get_contents('composer.json'),true);foreach(\\$c['require']??[] as \\$p=>\\$v){if(preg_match('/\\|\\|/',\\$v)&&\\$p!=='php'&&!str_starts_with(\\$p,'typo3/')&&!str_starts_with(\\$p,'ext-')&&!str_starts_with(\\$p,'lib-'))echo \\$p.': '.\\$v.PHP_EOL;}\" 2>/dev/null"
+    type: script
+    command: |
+      command -v php >/dev/null 2>&1 || exit 0
+      [ -f composer.json ] || exit 0
+      php -r '
+      $c = json_decode(file_get_contents("composer.json"), true);
+      $hits = [];
+      foreach (($c["require"] ?? []) as $p => $v) {
+          if (strpos($v, "||") === false) { continue; }
+          if ($p === "php" || strpos($p, "typo3/") === 0 || strpos($p, "ext-") === 0 || strpos($p, "lib-") === 0) { continue; }
+          $hits[] = $p . ": " . $v;
+      }
+      echo implode(PHP_EOL, $hits) . PHP_EOL;
+      exit($hits === [] ? 0 : 1);
+      '
     severity: info
-    desc: "Identify non-TYPO3 dependencies with multi-major-version constraints (|| operator)"
+    desc: "Non-TYPO3 dependencies with multi-major-version constraints (|| operator) — each one must have its API usage verified against every major it admits (TU-51/TU-52/TU-53); fails while any such constraint is present"
 
   - id: TU-61
     type: not_contains
@@ -313,10 +355,10 @@ mechanical:
 
   # === PHP-CS-FIXER CONFIGURATION ===
   - id: TU-37
-    type: command
-    pattern: "ls Build/php-cs-fixer/php-cs-fixer.php .php-cs-fixer.php .php-cs-fixer.dist.php 2>/dev/null | head -1 || echo 'NOT_FOUND'"
+    type: file_exists
+    target: "{Build/php-cs-fixer/php-cs-fixer.php,Build/.php-cs-fixer.php,Build/.php-cs-fixer.dist.php,.php-cs-fixer.php,.php-cs-fixer.dist.php}"
     severity: info
-    desc: "PHP-CS-Fixer configuration should exist for code style enforcement"
+    desc: "PHP-CS-Fixer configuration should exist for code style enforcement (root or Build/ subdir)"
 
   # === CHANGELOG ===
   - id: TU-38
@@ -335,8 +377,12 @@ mechanical:
 
   # === SINGLETONINTERFACE DEPRECATION (TYPO3 v14) ===
   - id: TU-54
-    type: command
-    pattern: 'for d in Classes src; do [ -d "$d" ] && grep -rql "SingletonInterface" "$d" 2>/dev/null && exit 1; done; exit 0'
+    type: script
+    command: |
+      for d in Classes src; do
+        [ -d "$d" ] && grep -rql "SingletonInterface" "$d" 2>/dev/null && exit 1
+      done
+      exit 0
     severity: warning
     desc: "SingletonInterface is deprecated in TYPO3 v14. Migrate to proper DI scoping (Services.yaml shared: true) unless the class must be used with GeneralUtility::setSingletonInstance in tests."
 

--- a/skills/typo3-extension-upgrade/checkpoints.yaml
+++ b/skills/typo3-extension-upgrade/checkpoints.yaml
@@ -14,25 +14,49 @@ mechanical:
   # keep testing/CI tooling under Build/). Build/rector/rector.php is the
   # Netresearch default when using a split Build/ structure.
   #
-  # The content checks here use `script` checkpoints that loop over candidate
-  # paths and only `grep` files that actually exist — `grep -l a b c` exits with
-  # status 2 when any listed file is missing, which would otherwise mask real
-  # matches in other candidates. A loop needs `;`/`&&`, which the runner's
-  # one-line allowlist refuses, so the body is a `type: script` literal block.
-  # The runner's brace-expansion in `file_exists` is used for TU-01/TU-04/TU-37
-  # since those are pure existence checks.
+  # TU-02, TU-03, TU-56 and TU-57 must judge ONE configuration, or they can
+  # disagree about which file is authoritative on an extension that carries
+  # several. Each of the four therefore opens with the same byte-identical
+  # resolution block, whose precedence mirrors Rector's own
+  # `RectorConfigsResolver` (vendor/rector/rector/src/Bootstrap):
+  #   1. the `--config`/`-c` path named next to a `rector` invocation in
+  #      composer.json, Makefile, Build/Scripts, .github/workflows or
+  #      .gitlab-ci.yml — accepted only when it ends in `.php` and exists;
+  #   2. rector.php, then rector.dist.php (Rector's own cwd fallbacks);
+  #   3. Build/rector.php, then Build/rector/rector.php (the split Build/
+  #      layout, which Rector itself only reaches via an explicit --config).
+  # The scrape honours a bare literal path only. A config path held in a
+  # variable, built by a wrapper script, split across lines, or written inside
+  # quotes (`--config 'Build/rector.php'`) falls through to step 2/3 — the
+  # four still agree, they just fall back to the fixed order.
+  #
+  # The bodies are `type: script` literal blocks because a loop needs `;`/`&&`,
+  # which the runner's one-line allowlist refuses. The runner's brace-expansion
+  # in `file_exists` is used for TU-01/TU-04/TU-37 since those are pure
+  # existence checks; TU-01's brace must list the same candidates as the
+  # resolution block, or it reports "missing" for a file the other four read.
   - id: TU-01
     type: file_exists
-    target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
+    target: "{rector.php,rector.dist.php,Build/rector.php,Build/rector/rector.php}"
     severity: warning
     desc: "rector.php should exist for automated code migration (root or Build/ subdir)"
 
   - id: TU-02
     type: script
     command: |
-      for f in rector.php Build/rector.php Build/rector/rector.php; do
-        [ -f "$f" ] && grep -q "Typo3LevelSetList" "$f" && exit 0
+      cfg=""
+      for c in $(grep -rhE -- '[Rr]ector' composer.json Makefile Build/Scripts .github/workflows .gitlab-ci.yml 2>/dev/null \
+        | grep -ohE -- "(--config[= ]+|-c +)[^ \",')]+\.php" \
+        | sed -E "s/^(--config[= ]+|-c +)//"); do
+        [ -f "$c" ] && cfg="$c" && break
       done
+      if [ -z "$cfg" ]; then
+        for c in rector.php rector.dist.php Build/rector.php Build/rector/rector.php; do
+          [ -f "$c" ] && cfg="$c" && break
+        done
+      fi
+      [ -z "$cfg" ] && exit 1
+      grep -q "Typo3LevelSetList" "$cfg" && exit 0
       exit 1
     severity: warning
     desc: "Rector config should use TYPO3 level sets for version upgrades"
@@ -40,9 +64,19 @@ mechanical:
   - id: TU-03
     type: script
     command: |
-      for f in rector.php Build/rector.php Build/rector/rector.php; do
-        [ -f "$f" ] && grep -q "RectorConfig" "$f" && exit 0
+      cfg=""
+      for c in $(grep -rhE -- '[Rr]ector' composer.json Makefile Build/Scripts .github/workflows .gitlab-ci.yml 2>/dev/null \
+        | grep -ohE -- "(--config[= ]+|-c +)[^ \",')]+\.php" \
+        | sed -E "s/^(--config[= ]+|-c +)//"); do
+        [ -f "$c" ] && cfg="$c" && break
       done
+      if [ -z "$cfg" ]; then
+        for c in rector.php rector.dist.php Build/rector.php Build/rector/rector.php; do
+          [ -f "$c" ] && cfg="$c" && break
+        done
+      fi
+      [ -z "$cfg" ] && exit 1
+      grep -q "RectorConfig" "$cfg" && exit 0
       exit 1
     severity: warning
     desc: "Rector config should use modern RectorConfig format"
@@ -68,9 +102,16 @@ mechanical:
     type: script
     command: |
       cfg=""
-      for f in rector.php Build/rector.php Build/rector/rector.php; do
-        [ -f "$f" ] && cfg="$f" && break
+      for c in $(grep -rhE -- '[Rr]ector' composer.json Makefile Build/Scripts .github/workflows .gitlab-ci.yml 2>/dev/null \
+        | grep -ohE -- "(--config[= ]+|-c +)[^ \",')]+\.php" \
+        | sed -E "s/^(--config[= ]+|-c +)//"); do
+        [ -f "$c" ] && cfg="$c" && break
       done
+      if [ -z "$cfg" ]; then
+        for c in rector.php rector.dist.php Build/rector.php Build/rector/rector.php; do
+          [ -f "$c" ] && cfg="$c" && break
+        done
+      fi
       [ -z "$cfg" ] && exit 0
       grep -q "UP_TO_TYPO3_14" "$cfg" && exit 0
       grep -qE "UP_TO_TYPO3_1[0-3]" "$cfg" && exit 1
@@ -82,9 +123,16 @@ mechanical:
     type: script
     command: |
       cfg=""
-      for f in rector.php Build/rector.php Build/rector/rector.php; do
-        [ -f "$f" ] && cfg="$f" && break
+      for c in $(grep -rhE -- '[Rr]ector' composer.json Makefile Build/Scripts .github/workflows .gitlab-ci.yml 2>/dev/null \
+        | grep -ohE -- "(--config[= ]+|-c +)[^ \",')]+\.php" \
+        | sed -E "s/^(--config[= ]+|-c +)//"); do
+        [ -f "$c" ] && cfg="$c" && break
       done
+      if [ -z "$cfg" ]; then
+        for c in rector.php rector.dist.php Build/rector.php Build/rector/rector.php; do
+          [ -f "$c" ] && cfg="$c" && break
+        done
+      fi
       [ -z "$cfg" ] && exit 0
       grep -q "UP_TO_PHP_" "$cfg" && exit 0
       exit 1
@@ -326,14 +374,15 @@ mechanical:
       command -v php >/dev/null 2>&1 || exit 0
       [ -f composer.json ] || exit 0
       php -r '
-      $c = json_decode(file_get_contents("composer.json"), true);
+      $c = json_decode((string) @file_get_contents("composer.json"), true);
+      if (!is_array($c) || !is_array($c["require"] ?? null)) { exit(0); }
       $hits = [];
-      foreach (($c["require"] ?? []) as $p => $v) {
-          if (strpos($v, "||") === false) { continue; }
+      foreach ($c["require"] as $p => $v) {
+          if (!is_string($v) || strpos($v, "||") === false) { continue; }
           if ($p === "php" || strpos($p, "typo3/") === 0 || strpos($p, "ext-") === 0 || strpos($p, "lib-") === 0) { continue; }
           $hits[] = $p . ": " . $v;
       }
-      echo implode(PHP_EOL, $hits) . PHP_EOL;
+      if ($hits !== []) { echo implode(PHP_EOL, $hits), PHP_EOL; }
       exit($hits === [] ? 0 : 1);
       '
     severity: info


### PR DESCRIPTION
TU-02, TU-03, TU-05, TU-37, TU-54, TU-56, TU-57 and TU-60 all carried command-chaining metacharacters in a single-line pattern. The runner refuses those before execution, so every one reported "blocked" on every project it was ever run against — the largest such cluster left in the estate. Each is now a screened script body checking what it always claimed to.

Measured against a real extension afterwards: 43 pass, 2 fail, 0 blocked, where before the run reported 8 blocked and could not speak to those eight at all.

---

Found by a mechanical re-run after the first sweep of ten skill repositories merged: this file still reported checks the runner refuses to execute, or failures nobody had triaged. Every repair is proved in both directions — a fixture carrying the real defect must still fail it. `validate-checkpoints.sh` reports 0 errors and 0 warnings.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01K6avYXLaWCBHmG21rkRbwn)_
