### PR TITLE
fix(v14): a removed class cannot be mocked, and swapping the name is not the fix

### DIFF
--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -152,6 +152,36 @@ argument and some public methods — so a match on either is a question rather
 than a defect, and they are deliberately absent from the search above. Work the
 table for those and for everything else, one row at a time rather than merged.
 
+#### When the hit is a mock target
+
+`createMock(RemovedClass::class)` cannot be repaired by replacing a type. There
+is nothing to mock — PHPUnit reflects over the class to build the double, and a
+class that no longer exists fails at that line:
+
+```
+PHPUnit\Framework\MockObject\Generator\UnknownTypeException:
+Class or interface "TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController"
+does not exist
+```
+
+This is the residue after the mechanical fixes, and it is the last thing left
+standing: measured, an upgrade that got everything else right reached 719 tests
+with 3 errors, all of them this. It survives because the search finds it and a
+search-and-replace cannot fix it — the decision is what the test should now
+assert, not which name to substitute.
+
+Two honest answers, and which one applies is a judgement about the test:
+
+- **The behaviour still exists, reached differently.** Mock what replaced the
+  class — for `TypoScriptFrontendController`, the request and its attributes —
+  and assert against that instead.
+- **The behaviour is gone with the class.** Delete the test. A test for a code
+  path that v14 removed is not a regression guard, and keeping it alive by
+  mocking something adjacent is how a suite starts asserting its own scaffolding.
+
+Do not reach for the third answer, which is neither: leaving the test in place
+with the mock target swapped for whatever happens to exist.
+
 #### When the hit is inside a type declaration
 
 A removed class in a property, parameter or return type cannot be replaced by


### PR DESCRIPTION
The last thing standing after every mechanical fix is `createMock` on a class that no longer exists. It survives precisely because the search finds it and a search-and-replace cannot repair it: PHPUnit reflects over the class to build the double, so there is nothing to substitute.

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals). An upgrade that got everything else right — `v14.3.6` installed, the suite loading, **719 tests running** — ended on 3 errors, all of them:

```
PHPUnit\Framework\MockObject\Generator\UnknownTypeException:
Class or interface "TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController" does not exist
Tests/Unit/Classes/Service/FrontendControllerServiceTest.php:230
```

That is the furthest any trial of this case has reached — the earlier ones never resolved the dependency, or the suite refused to load at all.

The new section gives the two honest answers and says the decision is a judgement about the test rather than a substitution: mock what replaced the class where the behaviour still exists, or delete the test where the behaviour went with the class. It also names the third answer as the one to avoid — keeping the test alive by mocking whatever happens to exist, which is how a suite starts asserting its own scaffolding.

Sits directly above [#58](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/58)'s type-declaration section, which handles the case one step earlier in the same file.

https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8
