### PR TITLE
fix(workflow): name the Tests/ search in the step, not only in the reference

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -27,7 +27,14 @@ Extension code only, not project/core upgrades.
 6. Run `fractor process --dry-run` then review and apply
 7. Run `php-cs-fixer fix`
 8. Run `phpstan analyse` **against each supported dependency version** and fix errors
-9. Run `phpunit` and fix tests
+9. Run `phpunit` and fix tests. **`Tests/` is part of the upgrade, not a
+   consequence of it.** A class v14 removed, referenced from a test, is fatal
+   rather than failing: in an import, a parent, a property or a signature it
+   stops PHPUnit while it loads the suite, so nothing runs at all. Search for
+   the removed types across both trees before running anything:
+   `grep -rnE 'TypoScriptFrontendController|StandaloneView|TemplateView|HashService|LocalPreviewHelper|LocalCropScaleMaskHelper|FreezableBackendInterface' Classes/ Tests/`
+   Every hit is a fix. `createMock` on one of them cannot be repaired by
+   swapping the name — see `references/upgrade-v13-to-v14.md`
 10. **Install the target version and run the suite against it.** A green suite
     on the version already installed proves nothing about the target — that is
     the old code passing old tests. Install first, then test:


### PR DESCRIPTION
The reference has said since [#56](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/56) that a removed class in `Tests/` stops PHPUnit while it loads the suite, and [#67](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/67) added what to do when the hit is a mock target. Neither reaches an agent that opens no reference.

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), across one round's four `candidate` trials:

| | references opened | `Tests/` edits | outcome |
|---|---|---|---|
| 3 of 4 | **none** | none | suite failed to load |
| 1 of 4 | `pre-upgrade.md`, `upgrade-v13-to-v14.md` | 28 | worked `createMock` 95 times — exactly the problem those sections describe |

Same shape as the constraint fix in [#60](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/60): the value that decides the step belongs in the step. Step 9 now says `Tests/` is part of the upgrade rather than a consequence of it, carries the one search over the removed types across both trees, and points at the reference for the mock case rather than restating it.

https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8
