### PR TITLE
fix(workflow): adding a version is not replacing one

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -22,6 +22,16 @@ Extension code only, not project/core upgrades.
 1. Complete planning phase (consult `references/pre-upgrade.md`)
 2. Create feature branch (verify git is clean)
 3. Update `composer.json` constraints for the target version. **v14's LTS minor is 3: write `^14.3`, never `^14.4`** — `^13.4 || ^14.3` to support both. v11.5, v12.4 and v13.4 make `14.4` look like the next in line; it matches no release, so `composer update` fails dependency resolution, exits non-zero and installs nothing. Constraints for every version pair: `references/upgrade-v13-to-v14.md`
+
+   **Adding a version is not replacing one.** Writing `^14.3` alone drops
+   support for every line the extension had before, which is a breaking change
+   for everyone installing it — and it is the cheap way to make the new line
+   resolve, so it happens by accident. "Make it work with the current LTS"
+   asks for the new line, not for the loss of the old one. Keep both
+   (`^13.4 || ^14.3`) unless dropping one was asked for explicitly, and if you
+   do drop it, say so where a maintainer will see it. Whether one codebase
+   *can* serve both is a separate question, answered in
+   `references/dual-compatibility.md`.
 4. **Audit third-party dependencies** for major version changes (consult `references/third-party-dependency-upgrades.md`)
 5. Run `rector process --dry-run` then review and apply
 6. Run `fractor process --dry-run` then review and apply

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -27,11 +27,13 @@ Extension code only, not project/core upgrades.
    support for every line the extension had before, which is a breaking change
    for everyone installing it — and it is the cheap way to make the new line
    resolve, so it happens by accident. "Make it work with the current LTS"
-   asks for the new line, not for the loss of the old one. Keep both
-   (`^13.4 || ^14.3`) unless dropping one was asked for explicitly, and if you
-   do drop it, say so where a maintainer will see it. Whether one codebase
-   *can* serve both is a separate question, answered in
-   `references/dual-compatibility.md`.
+   asks for the new line, not for the loss of the old ones.
+   **Read the existing constraint and keep every line in it**, then add the
+   target: `^12.4 || ^13.4` becomes `^12.4 || ^13.4 || ^14.3`, and only an
+   extension that already supported v13 alone ends up at `^13.4 || ^14.3`.
+   Drop a line only where that was asked for, and say so where a maintainer
+   will see it. Whether one codebase *can* serve them all is a separate
+   question, answered in `references/dual-compatibility.md`.
 4. **Audit third-party dependencies** for major version changes (consult `references/third-party-dependency-upgrades.md`)
 5. Run `rector process --dry-run` then review and apply
 6. Run `fractor process --dry-run` then review and apply


### PR DESCRIPTION
Step 3 offered `^13.4 || ^14.3` as a way to support both and never said that the alternative loses something. Narrowing the constraint to the target line is the cheapest way to make it resolve, so it happens without a decision being made — and it is a breaking change for everyone installing the extension.

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals). The first trial in this case's history to pass the v14 leg reached it exactly that way:

| leg | result |
|---|---|
| **14.3** | `RESOLVE=ok TESTS=passed INSTALLED=v14.3.6` — 719 tests, 1176 assertions |
| 13.4 | `RESOLVE=failed` — `composer.json` now reads `^14.3` alone |

The upgrade worked, and the extension had quietly stopped supporting the version it shipped with that morning. Thirteen rounds to get a suite green against v14, and the first one to manage it did so by dropping v13.

*"Make it work with the current LTS"* asks for the new line, not for the loss of the old one. The step now says to keep both unless dropping one was asked for, and to say so where a maintainer will see it if you do. Whether one codebase *can* serve both stays where it was, in `references/dual-compatibility.md`.

https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8
