### PR TITLE
fix(v14): removing the import is not removing the usage

### DIFF
--- a/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
+++ b/skills/typo3-extension-upgrade/references/upgrade-v13-to-v14.md
@@ -152,6 +152,27 @@ argument and some public methods — so a match on either is a question rather
 than a defect, and they are deliberately absent from the search above. Work the
 table for those and for everything else, one row at a time rather than merged.
 
+#### Removing the import is not removing the usage
+
+Deleting `use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;`
+and leaving `TypoScriptFrontendController::class` in a method body does not
+remove the reference. PHP resolves the unqualified name through the current
+namespace instead, so the code now names a class nobody ever wrote:
+
+```
+Class or interface "Netresearch\Contexts\Tests\Unit\Context\TypoScriptFrontendController"
+does not exist
+```
+
+Measured, and it is worse than it looks: on the target line the class is gone
+either way, so this edit changes nothing there — but on the line the extension
+still has to support, the class *does* exist, and the import was what reached
+it. Removing the import breaks the leg that was working while leaving the
+broken one broken. One trial passed v14.3 and lost v13.4 to exactly this, five
+errors, all of them a mock on a name that resolves nowhere.
+
+Search for the class name, not the import line, and change the usage.
+
 #### When the hit is a mock target
 
 `createMock(RemovedClass::class)` cannot be repaired by replacing a type. There


### PR DESCRIPTION
Deleting `use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;` and leaving `TypoScriptFrontendController::class` in a method body does not remove the reference. PHP resolves the unqualified name through the current namespace, so the code ends up naming a class nobody ever wrote:

```
Class or interface "Netresearch\Contexts\Tests\Unit\Context\TypoScriptFrontendController" does not exist
```

**Measured** in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), and worse than it looks.

On the target line the class is gone either way, so the edit changes nothing there. On the line the extension still has to support, the class *does* exist and the import was what reached it — so removing the import **breaks the leg that was working** and leaves the broken one broken.

One trial passed v14.3 and lost v13.4 to exactly this: five errors, every one a mock on a name that resolves nowhere. It is the first trial in this case's history to have both legs installing (`^12.4 || ^13.4 || ^14.3`, after [#70](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/70)), which is why the failure was visible at all — before, the second leg never got far enough to fail this way.

The instruction is to search for the class name rather than the import line, and to change the usage. Sits above [#67](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/67)'s mock-target section, which handles what to do once the usage is found.

https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8
