### PR TITLE
fix: install the target in two passes, and never call an untested upgrade green

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -51,10 +51,11 @@ Extension code only, not project/core upgrades.
     on the version already installed proves nothing about the target — that is
     the old code passing old tests. Install first, in two passes, then test:
     ```bash
-    composer update "typo3/*" --with typo3/cms-core:^14.3 -W --no-install
-    rm -rf vendor && composer install
-    vendor/bin/phpunit -c Build/phpunit/UnitTests.xml
+    composer update "typo3/*" --with typo3/cms-core:^14.3 -W --no-install \
+      && rm -rf vendor && composer install \
+      && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml
     ```
+    Chained, so a failed install stops before PHPUnit runs against the old tree.
     One pass fails on the way from v13 to v14: Composer upgrades
     `typo3/class-alias-loader` and then runs the old plugin against the new
     files, which dies with `Class "…\CaseSensitiveToken" not found` after the

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -49,11 +49,23 @@ Extension code only, not project/core upgrades.
    swapping the name — see `references/upgrade-v13-to-v14.md`
 10. **Install the target version and run the suite against it.** A green suite
     on the version already installed proves nothing about the target — that is
-    the old code passing old tests. Install first, then test:
-    `composer update "typo3/*" --with typo3/cms-core:^14.3 -W && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml`
+    the old code passing old tests. Install first, in two passes, then test:
+    ```bash
+    composer update "typo3/*" --with typo3/cms-core:^14.3 -W --no-install
+    rm -rf vendor && composer install
+    vendor/bin/phpunit -c Build/phpunit/UnitTests.xml
+    ```
+    One pass fails on the way from v13 to v14: Composer upgrades
+    `typo3/class-alias-loader` and then runs the old plugin against the new
+    files, which dies with `Class "…\CaseSensitiveToken" not found` after the
+    lock file is written. `composer install` on top of the old `vendor/` dies the
+    same way, so `vendor/` goes first.
     The package argument matters: without it `composer update` moves every
     dependency, and the test result then depends on upgrades that have nothing
     to do with TYPO3. `-W` lets the TYPO3 packages' own dependencies follow.
+    **If the target will not install, the upgrade is untested.** Say so in the
+    report, with the error, and do not report the suite as passing: a green run
+    on the version that was already there is that version's result.
 11. Verify success criteria (consult `references/verification.md`)
 
 **Done means the suite passes with the target version installed.** Not that the


### PR DESCRIPTION
Step 10 ("install the target version and run the suite against it") gave a one-line `composer update "typo3/*" --with typo3/cms-core:^14.3 -W && vendor/bin/phpunit …`. On the way from v13 to v14 that command fails after writing the lock file: Composer upgrades `typo3/class-alias-loader` and runs the old plugin against the new files, `Class "…\CaseSensitiveToken" not found`.

## Change

- Install in two passes: resolve with `--no-install`, remove `vendor/`, `composer install`, then run the suite. Reproduced on the agent-system-evals upgrade image: the one-pass command dies as above, the two-pass sequence installs TYPO3 14.3 and the suite runs.
- If the target does not install, the upgrade is untested: the report has to say so, with the error, and must not call the suite green.

## Why the second point

In the benchmark's round 17 (Haiku 4.5, OFR-TYPO3-UPGRADE-001), an agent's install failed, it ran the suite on the version already installed and reported "All 719 unit tests pass" for a tree whose v14 leg fails at load time. The install failure there had an environment cause as well, fixed separately in agent-system-evals; the reporting rule holds whatever the cause.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8)_
