### PR TITLE
fix: require the proof of done in the report, and forbid stopping to ask

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -53,9 +53,12 @@ Extension code only, not project/core upgrades.
     ```bash
     composer update "typo3/*" --with typo3/cms-core:^14.3 -W --no-install \
       && rm -rf vendor && composer install \
-      && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml
+      && composer show typo3/cms-core | grep '^versions' \
+      && vendor/bin/phpunit -c Build/phpunit/UnitTests.xml; echo "exit=$?"
     ```
-    Chained, so a failed install stops before PHPUnit runs against the old tree.
+    Chained, so a failed install stops before PHPUnit runs against the old tree;
+    the `versions` line says what was actually installed, and `exit=` is the
+    status of whichever step ran last.
     One pass fails on the way from v13 to v14: Composer upgrades
     `typo3/class-alias-loader` and then runs the old plugin against the new
     files, which dies with `Class "…\CaseSensitiveToken" not found` after the
@@ -73,15 +76,17 @@ Extension code only, not project/core upgrades.
 constraint was widened, and not that the suite is green where it was already
 green.
 
-**Prove it in the report.** End it with two lines copied from the last run,
-not summarised: the `versions` line of `composer show typo3/cms-core`, and
-PHPUnit's final summary line with its exit status. If that run did not exit 0,
-the work is not done — go back to step 9. Measured: three agents reported
+**Prove it in the report.** End it with lines copied from the last run of the
+step 10 command, not summarised: the `versions` line, PHPUnit's final summary
+line, and the `exit=` line. Where there is no summary, copy what stands in its
+place — PHPUnit's `Message:` line when the suite would not load, Composer's
+error when the install failed. If that run did not print `exit=0`, the work is
+not done — go back to step 9. Measured: three agents reported
 success without such a run. One never installed the target; one tested only
 the version already installed; one ran the suite on the target three times, saw
 it fail to load each time, and still wrote "Done". Copying the lines is what
 makes the gap impossible to miss. Only where you cannot make the suite pass,
-report that, with those same two lines.
+report that, with those same lines.
 
 Where a removed class is referenced decides when it bites. In an `import`, a
 parent class, a property or a signature it is resolved while PHPUnit *loads*

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -73,6 +73,16 @@ Extension code only, not project/core upgrades.
 constraint was widened, and not that the suite is green where it was already
 green.
 
+**Prove it in the report.** End it with two lines copied from the last run,
+not summarised: the `versions` line of `composer show typo3/cms-core`, and
+PHPUnit's final summary line with its exit status. If that run did not exit 0,
+the work is not done — go back to step 9. Measured: three agents reported
+success without such a run. One never installed the target; one tested only
+the version already installed; one ran the suite on the target three times, saw
+it fail to load each time, and still wrote "Done". Copying the lines is what
+makes the gap impossible to miss. Only where you cannot make the suite pass,
+report that, with those same two lines.
+
 Where a removed class is referenced decides when it bites. In an `import`, a
 parent class, a property or a signature it is resolved while PHPUnit *loads*
 the suite, so nothing runs at all and the failure looks nothing like a test
@@ -96,6 +106,14 @@ is honest, and this one is neither.
 Green after a revert is the state you started in. The only green that counts is
 the one from step 10, with the target version installed and the migration in
 place.
+
+**Nor stop to ask whether to proceed.** Measured: an agent installed the
+target, counted the uses of a class the new version removed, ran
+`git reset --hard`, and asked whether it should do the refactoring. A request
+to make the extension work with the new version is that permission. Replacing
+what the new version removed *is* the upgrade, however many places use it — it
+is the work, not a finding to report back. Ask only about what the request
+leaves open, such as dropping a supported line (step 3).
 
 ## When NOT to Apply Automatically
 


### PR DESCRIPTION
After [#76](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/76) and the environment fix in agent-system-evals, agents can install the target version. In round 18 of OFR-TYPO3-UPGRADE-001 (Haiku 4.5) the arm with this skill passed 3 of 6 trials (the bare `nr` stack 1 of 6). The three failures are behavioural, not environmental:

| trial | installed v14 | last run on v14 | reported |
|---|---|---|---|
| `wVwp469` | no | — (tested v13 only) | "All tests pass" |
| `en3Vf8a` | yes | suite did not load, three times | "Done ✅" |
| `PqPxpAA` | yes | none — reset the branch after counting the removed class's uses | asked whether to proceed |

## Change

- **Prove it in the report:** the report ends with two copied lines from the last run — `composer show typo3/cms-core` `versions` line and PHPUnit's summary with its exit status. A run that did not exit 0 sends the agent back to step 9. Copying the lines makes a missing or failing run visible to the agent writing the report.
- **Nor stop to ask whether to proceed:** a request to make the extension work with the new version is the permission; replacing what the new version removed is the upgrade. Asking stays for what the request leaves open, such as dropping a supported line.

Body grows from 142 to 160 lines; `validate-skill.sh` 0 errors (the warnings are the existing missing Contents sections in references).

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8)_
