### PR TITLE
fix: test every supported line, and make the report a step

### DIFF
--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -70,23 +70,31 @@ Extension code only, not project/core upgrades.
     **If the target will not install, the upgrade is untested.** Say so in the
     report, with the error, and do not report the suite as passing: a green run
     on the version that was already there is that version's result.
-11. Verify success criteria (consult `references/verification.md`)
+11. **Run the same command for every older line the constraint keeps** —
+    `--with typo3/cms-core:^13.4` for `^13.4`, and so on. A migration that
+    turns the target green can break the line below it: measured, an agent got
+    v14 green, left v13's suite failing, and reported all three lines
+    compatible. Fix, then run every line again.
+12. **Write the report, ending with the output of the last run on each line,
+    pasted as it printed** — the `versions` line, PHPUnit's final summary line
+    and the `exit=` line. Where there is no summary, paste what stands in its
+    place: PHPUnit's `Message:` line when the suite would not load, Composer's
+    error when the install failed. Any `exit=` other than `0` means the work is
+    not done: go back to step 9. Committing past a red suite, or with
+    `--no-verify`, is not done either.
+13. Verify success criteria (consult `references/verification.md`)
 
-**Done means the suite passes with the target version installed.** Not that the
-constraint was widened, and not that the suite is green where it was already
-green.
+**Done means the suite passes on every line the constraint names, with that
+line installed.** Not that the constraint was widened, and not that the suite
+is green where it was already green.
 
-**Prove it in the report.** End it with lines copied from the last run of the
-step 10 command, not summarised: the `versions` line, PHPUnit's final summary
-line, and the `exit=` line. Where there is no summary, copy what stands in its
-place — PHPUnit's `Message:` line when the suite would not load, Composer's
-error when the install failed. If that run did not print `exit=0`, the work is
-not done — go back to step 9. Measured: three agents reported
-success without such a run. One never installed the target; one tested only
-the version already installed; one ran the suite on the target three times, saw
-it fail to load each time, and still wrote "Done". Copying the lines is what
-makes the gap impossible to miss. Only where you cannot make the suite pass,
-report that, with those same lines.
+The pasted lines are the point of step 12. Measured: agents asked to *prove*
+the result wrote "✅ 719 tests pass" instead, and among those who summarised,
+one had never installed the target, one had seen the suite fail to load three
+times, and one had seen three errors and thirteen failures and committed with
+`--no-verify`. A
+summary can say anything; a pasted `exit=1` cannot. Only where you cannot make
+the suite pass, report that, with those same lines.
 
 Where a removed class is referenced decides when it bites. In an `import`, a
 parent class, a property or a signature it is resolved while PHPUnit *loads*

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -82,9 +82,10 @@ Extension code only, not project/core upgrades.
     pasted as it printed** — the `versions` line, PHPUnit's final summary line
     and the `exit=` line. Where there is no summary, paste what stands in its
     place: PHPUnit's `Message:` line when the suite would not load, Composer's
-    error when the install failed. Any `exit=` other than `0` means the work is
-    not done: go back to step 9. Committing past a red suite, or with
-    `--no-verify`, is not done either.
+    error when the install failed. On a line that installed, any `exit=` other
+    than `0` means the work is not done: go back to step 9. A line whose install
+    failed is the untested case from step 11. Committing past a red suite, or
+    with `--no-verify`, is not done either.
 13. Verify success criteria (consult `references/verification.md`)
 
 **Done means the suite passes on every line the constraint names, with that

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -74,7 +74,10 @@ Extension code only, not project/core upgrades.
     `--with typo3/cms-core:^13.4` for `^13.4`, and so on. A migration that
     turns the target green can break the line below it: measured, an agent got
     v14 green, left v13's suite failing, and reported all three lines
-    compatible. Fix, then run every line again.
+    compatible. Fix, then run every line again. A line that cannot be
+    installed here at all — Composer cannot resolve or download it — is
+    untested, not failed: report it with Composer's error, and never drop it
+    from the constraint for that reason (step 3).
 12. **Write the report, ending with the output of the last run on each line,
     pasted as it printed** — the `versions` line, PHPUnit's final summary line
     and the `exit=` line. Where there is no summary, paste what stands in its
@@ -85,7 +88,8 @@ Extension code only, not project/core upgrades.
 13. Verify success criteria (consult `references/verification.md`)
 
 **Done means the suite passes on every line the constraint names, with that
-line installed.** Not that the constraint was widened, and not that the suite
+line installed** — every line that can be installed; the rest are reported as
+untested. Not that the constraint was widened, and not that the suite
 is green where it was already green.
 
 The pasted lines are the point of step 12. Measured: agents asked to *prove*


### PR DESCRIPTION
Round 19 of OFR-TYPO3-UPGRADE-001 (Haiku 4.5): the arm carrying this skill at [#77](https://github.com/netresearch/typo3-extension-upgrade-skill/pull/77) passed both matrix legs in 4 of 6 trials, the released stack in 0 of 6 (Fisher exact 0.061 two-sided).

The two failures show what the skill still does not ask for:

| trial | 13.4 | 14.3 | what happened |
|---|---|---|---|
| `H6Bmvfv` | failing | passed | got v14 green, never re-ran v13, reported all three lines compatible |
| `5V6h2k6` | passed | 3 errors, 13 failures | saw that on v14, then committed with `--no-verify` |

And the proof paragraph from #77 was ignored: none of six reports carried the `exit=` line; all summarised ("✅ 719 tests pass"). It stood as a paragraph after the last step — in this case the routing was fixed earlier by moving words to the front, and the same applies here.

## Change

- **Step 11:** run the step 10 command for every older line the constraint keeps (`--with typo3/cms-core:^13.4` …), fix, run every line again. A line that cannot be installed at all is **untested, not failed**: reported with Composer's error and never dropped from the constraint for that reason (step 3). Without that clause, steps 11 and 12 together would push an agent in an environment without that line's packages towards dropping it just to get a clean run.
- **Step 12:** the report, ending with the output of the last run on each line pasted as printed — `versions`, PHPUnit summary, `exit=`; any `exit=` other than 0 sends the agent back to step 9; committing past a red suite or with `--no-verify` is named as not done.
- **Done means** green on every line the constraint names that can be installed; the rest are reported as untested.
- The proof paragraph shrinks to the measured reason for step 12.

`validate-skill.sh` 0 errors. Copilot is out of review quota and CodeRabbit has not reviewed this PR; the second commit comes from my own review of the first.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01UMwD3uRo3fRYCySKBYPkX8)_
