### PR TITLE
chore(release): v3.12.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typo3-extension-upgrade",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "typo3-extension-upgrade",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "description": "Systematic TYPO3 extension upgrades with planning agents and commands",
   "author": {
     "name": "Netresearch DTT GmbH",


### PR DESCRIPTION
Version bump to 3.12.4 (patch). Changes since v3.12.3:

- docs: complete the marketplace setup steps
- docs: correct the skills-directory install instructions
- fix: install the target in two passes, and never call an untested upgrade green
- fix: stop PHPUnit when the install in step 10 fails
- fix: require the proof of done in the report, and forbid stopping to ask
- fix: let step 10 print the evidence the report has to copy
- fix: test every supported line, and make the report a step
- fix: a line that cannot be installed is untested, not failed
- fix: scope the non-zero exit rule to lines that installed
- chore(dependabot): remove the Dependabot configuration

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5